### PR TITLE
feat: #2 ナビゲーションとルーティングを導入

### DIFF
--- a/packages/app/lib/core/routes/router.dart
+++ b/packages/app/lib/core/routes/router.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:pokemon_breeder_app/pages/party_page.dart';
+// Pages
+import 'package:pokemon_breeder_app/pages/pokedex_page.dart';
+
+/// アプリ全体で使用する [GoRouter] インスタンス。
+///
+/// - ルート構成は [StatefulShellRoute.indexedStack] を利用し、
+///   ボトムナビゲーションバーでタブを切り替えても各タブの状態を保持する。
+/// - 主要タブは以下の 2 つ。
+///   1. 図鑑 (`/pokedex`)
+///   2. パーティ (`/party`)
+final goRouter = GoRouter(
+  initialLocation: '/pokedex',
+  navigatorKey: _rootNavigatorKey,
+  routes: [
+    // ボトムナビゲーション & タブ保持用の ShellRoute
+    StatefulShellRoute.indexedStack(
+      builder: (context, state, navigationShell) {
+        return Scaffold(
+          body: navigationShell,
+          bottomNavigationBar: NavigationBar(
+            selectedIndex: navigationShell.currentIndex,
+            onDestinationSelected: navigationShell.goBranch,
+            destinations: const [
+              NavigationDestination(
+                icon: Icon(Icons.search),
+                label: '図鑑',
+              ),
+              NavigationDestination(
+                icon: Icon(Icons.pets),
+                label: 'パーティ',
+              ),
+            ],
+          ),
+        );
+      },
+      branches: [
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/pokedex',
+              name: 'pokedex',
+              pageBuilder: (context, state) => const NoTransitionPage(
+                child: PokedexPage(),
+              ),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: '/party',
+              name: 'party',
+              pageBuilder: (context, state) => const NoTransitionPage(
+                child: PartyPage(),
+              ),
+            ),
+          ],
+        ),
+      ],
+    ),
+  ],
+);
+
+final _rootNavigatorKey = GlobalKey<NavigatorState>();

--- a/packages/app/lib/main.dart
+++ b/packages/app/lib/main.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:pokemon_breeder_app/pages/party_page.dart';
+import 'package:pokemon_breeder_app/core/routes/router.dart';
 
 void main() {
   runApp(
@@ -15,9 +15,9 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       theme: ThemeData.light(useMaterial3: true),
-      home: const PartyPage(),
+      routerConfig: goRouter,
     );
   }
 }

--- a/packages/app/lib/pages/party_page.dart
+++ b/packages/app/lib/pages/party_page.dart
@@ -10,23 +10,6 @@ class PartyPage extends StatelessWidget {
       topBarContent: const DsTopBar(
         content: Text('パーティ'),
       ),
-      bottomBarContent: [
-        DsButton.iconText(
-          icon: Icons.catching_pokemon,
-          label: '図鑑',
-          onPressed: () {},
-        ),
-        DsButton.iconText(
-          icon: Icons.people,
-          label: 'パーティ',
-          onPressed: () {},
-        ),
-        DsButton.iconText(
-          icon: Icons.settings,
-          label: '設定',
-          onPressed: () {},
-        ),
-      ],
       body: Stack(
         children: [
           GridView.builder(

--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   design_system:
     path: ../design_system
   flutter_riverpod: ^2.6.1
+  go_router: ^15.2.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -288,6 +288,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  go_router:
+    dependency: transitive
+    description:
+      name: go_router
+      sha256: f222e12c5360b0c90aae5d33e6b351a6789d4aa1c97b32691b4a30946fc91813
+      url: "https://pub.dev"
+    source: hosted
+    version: "15.2.0"
   graphs:
     dependency: transitive
     description:


### PR DESCRIPTION
## 対応する Issue

Closes #2

## リンク

- なし

## やったこと

- `go_router` パッケージを追加し、依存を解決
- `packages/app/lib/core/routes/router.dart` を新規作成し GoRouter 設定を実装
  - `StatefulShellRoute.indexedStack` で図鑑 / パーティの 2 ルートを定義
  - `NavigationBar` によるボトムタブ UI を追加
- `main.dart` を `MaterialApp.router` へ移行し `goRouter` を適用
- `PartyPage` 内部の暫定 BottomBar を削除（ルートと重複するため）
- `pubspec.yaml` の依存更新および `pubspec.lock` 反映

## やらなかったこと

- 設定画面タブの追加
- `go_router_builder` による型安全ルーティング

## ユーザーへの影響

- ボトムタブで「図鑑」「パーティ」間をシームレスに切り替え可能
- 各タブのスクロール位置などの状態が保持される

## 動作確認

### 確認した環境

- Pixel 6a (実機) / Android 15
- iPhone 16 Plus (Simulator) / iOS 18
- Chrome (Web)

### 確認したこと

- アプリ起動時に図鑑画面が表示される
- タブ切り替えで画面が遷移し、状態が保持される
- Android 戻るボタンでタブ内の履歴がポップする

### 確認しなかった（できなかった）こと

- Deep Link / URL からの直接遷移

## その他

- 今後 `go_router_builder` 導入によるルートの型安全化を検討してください。
