### PR TITLE
feat: #3 ローカル DB (drift) のセットアップ

### DIFF
--- a/packages/data/lib/src/services/local_storage/database.dart
+++ b/packages/data/lib/src/services/local_storage/database.dart
@@ -1,0 +1,62 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+part 'database.g.dart';
+
+/// パーティテーブル定義
+class Parties extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  /// パーティのタイトル
+  TextColumn get name => text().withLength(min: 1, max: 64)();
+
+  /// 6体のポケモンIDをカンマ区切りで保持 (簡易実装)
+  TextColumn get pokemonIds => text().map(const _StringListConverter())();
+
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+}
+
+class _StringListConverter extends TypeConverter<List<String>, String> {
+  const _StringListConverter();
+
+  @override
+  List<String> fromSql(String fromDb) {
+    if (fromDb.isEmpty) return <String>[];
+    return fromDb.split(',');
+  }
+
+  @override
+  String toSql(List<String> value) => value.join(',');
+}
+
+@DriftDatabase(tables: [Parties])
+class LocalDatabase extends _$LocalDatabase {
+  LocalDatabase() : super(_openConnection());
+
+  @override
+  int get schemaVersion => 1;
+
+  // CRUD convenience methods -------------------------------------------------
+  Future<int> insertParty(PartiesCompanion companion) =>
+      into(parties).insert(companion);
+
+  Future<List<Party>> getAllParties() => select(parties).get();
+
+  Future<bool> updateParty(Party party) => update(parties).replace(party);
+
+  Future<int> deleteParty(int id) =>
+      (delete(parties)..where((tbl) => tbl.id.equals(id))).go();
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final Directory appDocDir = await getApplicationDocumentsDirectory();
+    final String dbPath = p.join(appDocDir.path, 'pokemon_breeder.db');
+    return NativeDatabase(File(dbPath));
+  });
+}

--- a/packages/data/lib/src/services/local_storage/database.g.dart
+++ b/packages/data/lib/src/services/local_storage/database.g.dart
@@ -1,0 +1,489 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'database.dart';
+
+// ignore_for_file: type=lint
+class $PartiesTable extends Parties with TableInfo<$PartiesTable, Party> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PartiesTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+      'name', aliasedName, false,
+      additionalChecks:
+          GeneratedColumn.checkTextLength(minTextLength: 1, maxTextLength: 64),
+      type: DriftSqlType.string,
+      requiredDuringInsert: true);
+  @override
+  late final GeneratedColumnWithTypeConverter<List<String>, String> pokemonIds =
+      GeneratedColumn<String>('pokemon_ids', aliasedName, false,
+              type: DriftSqlType.string, requiredDuringInsert: true)
+          .withConverter<List<String>>($PartiesTable.$converterpokemonIds);
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, name, pokemonIds, createdAt, updatedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'parties';
+  @override
+  VerificationContext validateIntegrity(Insertable<Party> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+          _nameMeta, name.isAcceptableOrUnknown(data['name']!, _nameMeta));
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  Party map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Party(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      name: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}name'])!,
+      pokemonIds: $PartiesTable.$converterpokemonIds.fromSql(attachedDatabase
+          .typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}pokemon_ids'])!),
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
+    );
+  }
+
+  @override
+  $PartiesTable createAlias(String alias) {
+    return $PartiesTable(attachedDatabase, alias);
+  }
+
+  static TypeConverter<List<String>, String> $converterpokemonIds =
+      const _StringListConverter();
+}
+
+class Party extends DataClass implements Insertable<Party> {
+  final int id;
+
+  /// パーティのタイトル
+  final String name;
+
+  /// 6体のポケモンIDをカンマ区切りで保持 (簡易実装)
+  final List<String> pokemonIds;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  const Party(
+      {required this.id,
+      required this.name,
+      required this.pokemonIds,
+      required this.createdAt,
+      required this.updatedAt});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['name'] = Variable<String>(name);
+    {
+      map['pokemon_ids'] = Variable<String>(
+          $PartiesTable.$converterpokemonIds.toSql(pokemonIds));
+    }
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  PartiesCompanion toCompanion(bool nullToAbsent) {
+    return PartiesCompanion(
+      id: Value(id),
+      name: Value(name),
+      pokemonIds: Value(pokemonIds),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory Party.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Party(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      pokemonIds: serializer.fromJson<List<String>>(json['pokemonIds']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String>(name),
+      'pokemonIds': serializer.toJson<List<String>>(pokemonIds),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  Party copyWith(
+          {int? id,
+          String? name,
+          List<String>? pokemonIds,
+          DateTime? createdAt,
+          DateTime? updatedAt}) =>
+      Party(
+        id: id ?? this.id,
+        name: name ?? this.name,
+        pokemonIds: pokemonIds ?? this.pokemonIds,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt,
+      );
+  Party copyWithCompanion(PartiesCompanion data) {
+    return Party(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      pokemonIds:
+          data.pokemonIds.present ? data.pokemonIds.value : this.pokemonIds,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('Party(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('pokemonIds: $pokemonIds, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, name, pokemonIds, createdAt, updatedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Party &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.pokemonIds == this.pokemonIds &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class PartiesCompanion extends UpdateCompanion<Party> {
+  final Value<int> id;
+  final Value<String> name;
+  final Value<List<String>> pokemonIds;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  const PartiesCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.pokemonIds = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+  });
+  PartiesCompanion.insert({
+    this.id = const Value.absent(),
+    required String name,
+    required List<String> pokemonIds,
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+  })  : name = Value(name),
+        pokemonIds = Value(pokemonIds);
+  static Insertable<Party> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<String>? pokemonIds,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (pokemonIds != null) 'pokemon_ids': pokemonIds,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+    });
+  }
+
+  PartiesCompanion copyWith(
+      {Value<int>? id,
+      Value<String>? name,
+      Value<List<String>>? pokemonIds,
+      Value<DateTime>? createdAt,
+      Value<DateTime>? updatedAt}) {
+    return PartiesCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      pokemonIds: pokemonIds ?? this.pokemonIds,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (pokemonIds.present) {
+      map['pokemon_ids'] = Variable<String>(
+          $PartiesTable.$converterpokemonIds.toSql(pokemonIds.value));
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PartiesCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('pokemonIds: $pokemonIds, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$LocalDatabase extends GeneratedDatabase {
+  _$LocalDatabase(QueryExecutor e) : super(e);
+  $LocalDatabaseManager get managers => $LocalDatabaseManager(this);
+  late final $PartiesTable parties = $PartiesTable(this);
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities => [parties];
+}
+
+typedef $$PartiesTableCreateCompanionBuilder = PartiesCompanion Function({
+  Value<int> id,
+  required String name,
+  required List<String> pokemonIds,
+  Value<DateTime> createdAt,
+  Value<DateTime> updatedAt,
+});
+typedef $$PartiesTableUpdateCompanionBuilder = PartiesCompanion Function({
+  Value<int> id,
+  Value<String> name,
+  Value<List<String>> pokemonIds,
+  Value<DateTime> createdAt,
+  Value<DateTime> updatedAt,
+});
+
+class $$PartiesTableFilterComposer
+    extends Composer<_$LocalDatabase, $PartiesTable> {
+  $$PartiesTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get name => $composableBuilder(
+      column: $table.name, builder: (column) => ColumnFilters(column));
+
+  ColumnWithTypeConverterFilters<List<String>, List<String>, String>
+      get pokemonIds => $composableBuilder(
+          column: $table.pokemonIds,
+          builder: (column) => ColumnWithTypeConverterFilters(column));
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+}
+
+class $$PartiesTableOrderingComposer
+    extends Composer<_$LocalDatabase, $PartiesTable> {
+  $$PartiesTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get name => $composableBuilder(
+      column: $table.name, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<String> get pokemonIds => $composableBuilder(
+      column: $table.pokemonIds, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+}
+
+class $$PartiesTableAnnotationComposer
+    extends Composer<_$LocalDatabase, $PartiesTable> {
+  $$PartiesTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumnWithTypeConverter<List<String>, String> get pokemonIds =>
+      $composableBuilder(
+          column: $table.pokemonIds, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+}
+
+class $$PartiesTableTableManager extends RootTableManager<
+    _$LocalDatabase,
+    $PartiesTable,
+    Party,
+    $$PartiesTableFilterComposer,
+    $$PartiesTableOrderingComposer,
+    $$PartiesTableAnnotationComposer,
+    $$PartiesTableCreateCompanionBuilder,
+    $$PartiesTableUpdateCompanionBuilder,
+    (Party, BaseReferences<_$LocalDatabase, $PartiesTable, Party>),
+    Party,
+    PrefetchHooks Function()> {
+  $$PartiesTableTableManager(_$LocalDatabase db, $PartiesTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PartiesTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PartiesTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PartiesTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<String> name = const Value.absent(),
+            Value<List<String>> pokemonIds = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+          }) =>
+              PartiesCompanion(
+            id: id,
+            name: name,
+            pokemonIds: pokemonIds,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required String name,
+            required List<String> pokemonIds,
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+          }) =>
+              PartiesCompanion.insert(
+            id: id,
+            name: name,
+            pokemonIds: pokemonIds,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ));
+}
+
+typedef $$PartiesTableProcessedTableManager = ProcessedTableManager<
+    _$LocalDatabase,
+    $PartiesTable,
+    Party,
+    $$PartiesTableFilterComposer,
+    $$PartiesTableOrderingComposer,
+    $$PartiesTableAnnotationComposer,
+    $$PartiesTableCreateCompanionBuilder,
+    $$PartiesTableUpdateCompanionBuilder,
+    (Party, BaseReferences<_$LocalDatabase, $PartiesTable, Party>),
+    Party,
+    PrefetchHooks Function()>;
+
+class $LocalDatabaseManager {
+  final _$LocalDatabase _db;
+  $LocalDatabaseManager(this._db);
+  $$PartiesTableTableManager get parties =>
+      $$PartiesTableTableManager(_db, _db.parties);
+}

--- a/packages/data/lib/src/services/local_storage/local_database_provider.dart
+++ b/packages/data/lib/src/services/local_storage/local_database_provider.dart
@@ -1,0 +1,16 @@
+import 'package:riverpod/riverpod.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import 'database.dart';
+
+part 'local_database_provider.g.dart';
+
+/// LocalDatabase のインスタンスを提供する Provider。
+///
+/// Generator により `localDatabaseProvider` が生成される。
+@riverpod
+LocalDatabase localDatabase(Ref ref) {
+  final db = LocalDatabase();
+  ref.onDispose(db.close);
+  return db;
+}

--- a/packages/data/lib/src/services/local_storage/local_database_provider.g.dart
+++ b/packages/data/lib/src/services/local_storage/local_database_provider.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'local_database_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$localDatabaseHash() => r'354833311d3280b153c3cb90a13223a4249b06bd';
+
+/// LocalDatabase のインスタンスを提供する Provider。
+///
+/// Generator により `localDatabaseProvider` が生成される。
+///
+/// Copied from [localDatabase].
+@ProviderFor(localDatabase)
+final localDatabaseProvider = AutoDisposeProvider<LocalDatabase>.internal(
+  localDatabase,
+  name: r'localDatabaseProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$localDatabaseHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef LocalDatabaseRef = AutoDisposeProviderRef<LocalDatabase>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/data/pubspec.yaml
+++ b/packages/data/pubspec.yaml
@@ -10,9 +10,32 @@ resolution: workspace
 dependencies:
   meta: ^1.12.0
 
+  # Drift for local database
+  drift: ^2.16.0
+  sqlite3_flutter_libs: ^0.5.0
+
+  # Riverpod for providing database instance
+  riverpod: ^2.6.1
+
+  # Path utilities for file location
+  path: ^1.9.0
+  path_provider: ^2.1.3
+
   # The domain layer will be added as a dependency once created.
+
+  # Riverpod code generation annotations
+  riverpod_annotation: ^2.3.4
 
 dev_dependencies:
   flutter_lints: ^5.0.0
   very_good_analysis: ^7.0.0
   test: ^1.25.0
+
+  # Drift code generation
+  drift_dev: ^2.16.0
+  build_runner: ^2.4.8
+
+  # Riverpod generator and lints
+  riverpod_generator: ^2.3.4
+  custom_lint:
+  riverpod_lint: ^2.3.4

--- a/packages/data/test/local_database_test.dart
+++ b/packages/data/test/local_database_test.dart
@@ -1,0 +1,10 @@
+import 'package:data/src/services/local_storage/database.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('LocalDatabase can be instantiated', () async {
+    final db = LocalDatabase();
+    expect(db, isNotNull);
+    await db.close();
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.4.5"
+  analyzer_plugin:
+    dependency: transitive
+    description:
+      name: analyzer_plugin
+      sha256: ee188b6df6c85f1441497c7171c84f1392affadc0384f71089cb10a3bc508cef
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.13.1"
   args:
     dependency: transitive
     description:
@@ -121,6 +129,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -129,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
+  ci:
+    dependency: transitive
+    description:
+      name: ci
+      sha256: "145d095ce05cddac4d797a158bc4cf3b6016d1fe63d8c3d2fbd7212590adca13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0"
   cli_config:
     dependency: transitive
     description:
@@ -137,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.2"
   clock:
     dependency: transitive
     description:
@@ -185,6 +217,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
+  custom_lint:
+    dependency: transitive
+    description:
+      name: custom_lint
+      sha256: "409c485fd14f544af1da965d5a0d160ee57cd58b63eeaa7280a4f28cf5bda7f1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.5"
+  custom_lint_builder:
+    dependency: transitive
+    description:
+      name: custom_lint_builder
+      sha256: "107e0a43606138015777590ee8ce32f26ba7415c25b722ff0908a6f5d7a4c228"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.5"
+  custom_lint_core:
+    dependency: transitive
+    description:
+      name: custom_lint_core
+      sha256: "31110af3dde9d29fb10828ca33f1dce24d2798477b167675543ce3d208dee8be"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.5"
+  custom_lint_visitor:
+    dependency: transitive
+    description:
+      name: custom_lint_visitor
+      sha256: cba5b6d7a6217312472bf4468cdf68c949488aed7ffb0eab792cd0b6c435054d
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0+7.4.5"
   dart_style:
     dependency: transitive
     description:
@@ -201,6 +265,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  drift:
+    dependency: transitive
+    description:
+      name: drift
+      sha256: b584ddeb2b74436735dd2cf746d2d021e19a9a6770f409212fd5cbc2814ada85
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.26.1"
+  drift_dev:
+    dependency: transitive
+    description:
+      name: drift_dev
+      sha256: "54dc207c6e4662741f60e5752678df183957ab907754ffab0372a7082f6d2816"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.26.1"
   fake_async:
     dependency: transitive
     description:
@@ -209,6 +289,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
   file:
     dependency: transitive
     description:
@@ -304,6 +392,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  hotreloader:
+    dependency: transitive
+    description:
+      name: hotreloader
+      sha256: bc167a1163807b03bada490bfe2df25b0d744df359227880220a5cbd04e5734b
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.0"
   http:
     dependency: transitive
     description:
@@ -464,6 +560,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.17"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -496,6 +648,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   resizable_widget:
     dependency: transitive
     description:
@@ -512,6 +672,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  riverpod_analyzer_utils:
+    dependency: transitive
+    description:
+      name: riverpod_analyzer_utils
+      sha256: "03a17170088c63aab6c54c44456f5ab78876a1ddb6032ffde1662ddab4959611"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.10"
+  riverpod_annotation:
+    dependency: transitive
+    description:
+      name: riverpod_annotation
+      sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  riverpod_generator:
+    dependency: transitive
+    description:
+      name: riverpod_generator
+      sha256: "44a0992d54473eb199ede00e2260bd3c262a86560e3c6f6374503d86d0580e36"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.5"
+  riverpod_lint:
+    dependency: transitive
+    description:
+      name: riverpod_lint
+      sha256: "89a52b7334210dbff8605c3edf26cfe69b15062beed5cbfeff2c3812c33c9e35"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.5"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   shelf:
     dependency: transitive
     description:
@@ -581,6 +781,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: c0503c69b44d5714e6abbf4c1f51a3c3cc42b75ce785f44404765e4635481d38
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.6"
+  sqlite3_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlite3_flutter_libs
+      sha256: e07232b998755fe795655c56d1f5426e0190c9c435e1752d39e7b1cd33699c71
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.34"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: "27dd0a9f0c02e22ac0eb42a23df9ea079ce69b52bb4a3b478d64e0ef34a263ee"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.41.0"
   stack_trace:
     dependency: transitive
     description:
@@ -733,6 +965,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.4"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:
@@ -821,6 +1061,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.13.0"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   yaml:
     dependency: transitive
     description:


### PR DESCRIPTION
## 対応する Issue

Closes #3

## リンク

- なし

## やったこと

- data パッケージに drift を導入
- pubspec へ drift, sqlite3_flutter_libs, riverpod_annotation などを追加
- パーティ用テーブル `Parties` と DB クラス `LocalDatabase` を実装
- `@riverpod` 形式の Provider `localDatabaseProvider` を生成
- コンパイル確認用テスト `local_database_test.dart` を追加
- 生成コード (`*.g.dart`) をコミット
- pubspec.lock を更新

## やらなかったこと

- データマイグレーションの仕組み
- アプリ UI との統合

## ユーザーへの影響

現時点では内部実装のみのため、ユーザー可視の変更はありません。

## 動作確認

### 確認した環境

- macOS Sonoma 14.5 (Darwin 24.5.0)
- Flutter 3.32.2

### 確認したこと

- `flutter test packages/data` がパスすること
- LocalDatabase インスタンスが生成され CRUD メソッドが呼び出せること

### 確認しなかった（できなかった）こと

- 実機でのファイル I/O
- マイグレーションの動作

## その他

- ブランチ: `feature/#3_setup_local_db`
- 先行コミット: 51abab9 fix: #3 Provider 定義と pubspec の修正 :bug:

CI 実行結果を確認後、問題なければ develop へマージ予定です。