### PR TITLE
feat: #4 データ層 (PokeAPI) のセットアップ

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Essential Commands
+- **Dependencies**: `make pub_get` - Install dependencies for all packages
+- **Testing**: `make test` - Run all tests across packages
+- **Build Analysis**: `make analyze` - Run static analysis on all packages
+- **Formatting**: `make format` - Format all Dart code
+- **Code Generation**: `make generate` - Run build_runner for all packages
+- **Clean Build**: `make clean_pub_get` - Clean and reinstall dependencies
+
+### Package-Specific Commands
+- **App Tests**: `make test_app` - Test app package only
+- **Data Tests**: `make test_data` - Test data package only
+- **Domain Tests**: `make test_domain` - Test domain package only
+
+### Development Tools
+- **Flutter Version Manager**: Uses `fvm` for Flutter version management
+- **repomix**: Available for generating repository snapshots (`make repomix_all`)
+
+## Architecture Overview
+
+### Package Structure
+This is a multi-package Flutter monorepo following Clean Architecture principles:
+
+- **`packages/app/`** - UI layer, routing, and application entry point
+- **`packages/design_system/`** - Reusable UI components and design tokens
+- **`packages/data/`** - Data sources, APIs, and local storage
+- **`packages/domain/`** - Business logic, entities, and use cases
+
+### Navigation System
+- **Router**: GoRouter with StatefulShellRoute.indexedStack
+- **Main Navigation**: Bottom navigation with two tabs (Pokedex, Party)
+- **State Preservation**: Tab states maintained when switching
+- **Missing**: Evolution flow pages not integrated into routing
+
+### Key Technologies
+- **Flutter**: 3.32.2
+- **State Management**: flutter_riverpod 2.6.1
+- **Navigation**: go_router 15.2.0
+- **Code Generation**: freezed 3.0.6, build_runner
+- **Data Source**: PokeAPI
+
+### Development Rules
+- **Type Safety**: Explicit type annotations required, avoid `dynamic`
+- **Null Safety**: Proper use of nullable/non-nullable types
+- **Immutability**: Use `freezed` for data classes, prefer `final`
+- **Error Handling**: Use Result types instead of exceptions
+- **Comments**: Japanese language, document public APIs with `///`
+- **Code Generation**: Commit generated `.g.dart` and `.freezed.dart` files
+
+### Current Implementation Status
+- ✅ Bottom navigation with Pokedex and Party pages
+- ✅ Design system with consistent styling
+- ✅ Basic Pokemon display components
+- ❌ Evolution pages not routed
+- ❌ Real data integration pending
+- ❌ Search functionality incomplete
+
+### Local Database
+- **Storage**: SQLite with drift
+- **Provider**: Uses Riverpod for dependency injection
+- **Location**: `packages/data/src/services/local_storage/`
+
+### Design System Usage
+All UI components should use the design system package:
+- Prefix components with `Ds` (e.g., `DsButton`, `DsScaffold`)
+- Use semantic colors and typography tokens
+- Follow established spacing and dimension guidelines
+
+### Testing Strategy
+- **Unit Tests**: Test business logic in domain layer
+- **Widget Tests**: Test UI components and pages
+- **Integration Tests**: Test complete user flows
+- **Database Tests**: Test local storage functionality

--- a/packages/data/lib/src/core/errors/data_exception.dart
+++ b/packages/data/lib/src/core/errors/data_exception.dart
@@ -1,0 +1,10 @@
+///  データ層でスローされる例外。
+class DataException implements Exception {
+  DataException(this.message, {this.original});
+
+  final String message;
+  final Object? original;
+
+  @override
+  String toString() => 'DataException: $message ${original ?? ''}';
+}

--- a/packages/data/lib/src/core/errors/data_failure.dart
+++ b/packages/data/lib/src/core/errors/data_failure.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'data_failure.freezed.dart';
+
+///  データ層で発生しうる失敗を表す型。
+@freezed
+sealed class DataFailure with _$DataFailure {
+  /// ネットワーク関連の失敗。
+  const factory DataFailure.network({required String message}) = _Network;
+
+  /// JSON などのパース失敗。
+  const factory DataFailure.parsing({required String message}) = _Parsing;
+
+  /// API から空レスポンスが返った場合の失敗。
+  const factory DataFailure.emptyResponse({String? message}) = _EmptyResponse;
+
+  /// その他の予期しない失敗。
+  const factory DataFailure.unexpected({required String message}) = _Unexpected;
+}

--- a/packages/data/lib/src/core/errors/data_failure.freezed.dart
+++ b/packages/data/lib/src/core/errors/data_failure.freezed.dart
@@ -1,0 +1,343 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'data_failure.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$DataFailure {
+  String? get message;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $DataFailureCopyWith<DataFailure> get copyWith =>
+      _$DataFailureCopyWithImpl<DataFailure>(this as DataFailure, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is DataFailure &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @override
+  String toString() {
+    return 'DataFailure(message: $message)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $DataFailureCopyWith<$Res> {
+  factory $DataFailureCopyWith(
+          DataFailure value, $Res Function(DataFailure) _then) =
+      _$DataFailureCopyWithImpl;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class _$DataFailureCopyWithImpl<$Res> implements $DataFailureCopyWith<$Res> {
+  _$DataFailureCopyWithImpl(this._self, this._then);
+
+  final DataFailure _self;
+  final $Res Function(DataFailure) _then;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_self.copyWith(
+      message: null == message
+          ? _self.message!
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _Network implements DataFailure {
+  const _Network({required this.message});
+
+  @override
+  final String message;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$NetworkCopyWith<_Network> get copyWith =>
+      __$NetworkCopyWithImpl<_Network>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Network &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @override
+  String toString() {
+    return 'DataFailure.network(message: $message)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$NetworkCopyWith<$Res>
+    implements $DataFailureCopyWith<$Res> {
+  factory _$NetworkCopyWith(_Network value, $Res Function(_Network) _then) =
+      __$NetworkCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$NetworkCopyWithImpl<$Res> implements _$NetworkCopyWith<$Res> {
+  __$NetworkCopyWithImpl(this._self, this._then);
+
+  final _Network _self;
+  final $Res Function(_Network) _then;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_Network(
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _Parsing implements DataFailure {
+  const _Parsing({required this.message});
+
+  @override
+  final String message;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$ParsingCopyWith<_Parsing> get copyWith =>
+      __$ParsingCopyWithImpl<_Parsing>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Parsing &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @override
+  String toString() {
+    return 'DataFailure.parsing(message: $message)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$ParsingCopyWith<$Res>
+    implements $DataFailureCopyWith<$Res> {
+  factory _$ParsingCopyWith(_Parsing value, $Res Function(_Parsing) _then) =
+      __$ParsingCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$ParsingCopyWithImpl<$Res> implements _$ParsingCopyWith<$Res> {
+  __$ParsingCopyWithImpl(this._self, this._then);
+
+  final _Parsing _self;
+  final $Res Function(_Parsing) _then;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_Parsing(
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _EmptyResponse implements DataFailure {
+  const _EmptyResponse({this.message});
+
+  @override
+  final String? message;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$EmptyResponseCopyWith<_EmptyResponse> get copyWith =>
+      __$EmptyResponseCopyWithImpl<_EmptyResponse>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _EmptyResponse &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @override
+  String toString() {
+    return 'DataFailure.emptyResponse(message: $message)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$EmptyResponseCopyWith<$Res>
+    implements $DataFailureCopyWith<$Res> {
+  factory _$EmptyResponseCopyWith(
+          _EmptyResponse value, $Res Function(_EmptyResponse) _then) =
+      __$EmptyResponseCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String? message});
+}
+
+/// @nodoc
+class __$EmptyResponseCopyWithImpl<$Res>
+    implements _$EmptyResponseCopyWith<$Res> {
+  __$EmptyResponseCopyWithImpl(this._self, this._then);
+
+  final _EmptyResponse _self;
+  final $Res Function(_EmptyResponse) _then;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? message = freezed,
+  }) {
+    return _then(_EmptyResponse(
+      message: freezed == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _Unexpected implements DataFailure {
+  const _Unexpected({required this.message});
+
+  @override
+  final String message;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$UnexpectedCopyWith<_Unexpected> get copyWith =>
+      __$UnexpectedCopyWithImpl<_Unexpected>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Unexpected &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  @override
+  String toString() {
+    return 'DataFailure.unexpected(message: $message)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$UnexpectedCopyWith<$Res>
+    implements $DataFailureCopyWith<$Res> {
+  factory _$UnexpectedCopyWith(
+          _Unexpected value, $Res Function(_Unexpected) _then) =
+      __$UnexpectedCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$UnexpectedCopyWithImpl<$Res> implements _$UnexpectedCopyWith<$Res> {
+  __$UnexpectedCopyWithImpl(this._self, this._then);
+
+  final _Unexpected _self;
+  final $Res Function(_Unexpected) _then;
+
+  /// Create a copy of DataFailure
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_Unexpected(
+      message: null == message
+          ? _self.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/data/lib/src/services/api/api_client.dart
+++ b/packages/data/lib/src/services/api/api_client.dart
@@ -1,0 +1,36 @@
+import 'package:dio/dio.dart';
+
+import '../../core/errors/data_exception.dart';
+
+/// API クライアント。PokeAPI への HTTP リクエストをラップする。
+class ApiClient {
+  ApiClient({Dio? dio})
+      : _dio = dio ??
+            Dio(
+              BaseOptions(
+                baseUrl: 'https://pokeapi.co/api/v2',
+                connectTimeout: const Duration(seconds: 10),
+                receiveTimeout: const Duration(seconds: 10),
+              ),
+            );
+
+  final Dio _dio;
+
+  /// GET リクエストを実行する。
+  Future<Response<T>> get<T>(
+    String path, {
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+  }) async {
+    try {
+      final response = await _dio.get<T>(
+        path,
+        queryParameters: queryParameters,
+        options: options,
+      );
+      return response;
+    } on DioException catch (e) {
+      throw DataException('Failed to GET $path', original: e);
+    }
+  }
+}

--- a/packages/data/lib/src/services/pokemon/model/pokemon_dto.dart
+++ b/packages/data/lib/src/services/pokemon/model/pokemon_dto.dart
@@ -1,0 +1,16 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pokemon_dto.freezed.dart';
+part 'pokemon_dto.g.dart';
+
+/// PokeAPI の /pokemon エンドポイントのレスポンス要素を表す DTO。
+@freezed
+class PokemonDto with _$PokemonDto {
+  const factory PokemonDto({
+    required String name,
+    required String url,
+  }) = _PokemonDto;
+
+  factory PokemonDto.fromJson(Map<String, dynamic> json) =>
+      _$PokemonDtoFromJson(json);
+}

--- a/packages/data/lib/src/services/pokemon/model/pokemon_dto.dart
+++ b/packages/data/lib/src/services/pokemon/model/pokemon_dto.dart
@@ -5,7 +5,9 @@ part 'pokemon_dto.g.dart';
 
 /// PokeAPI の /pokemon エンドポイントのレスポンス要素を表す DTO。
 @freezed
-class PokemonDto with _$PokemonDto {
+abstract class PokemonDto with _$PokemonDto {
+  const PokemonDto._(); // Add private constructor
+  
   const factory PokemonDto({
     required String name,
     required String url,

--- a/packages/data/lib/src/services/pokemon/model/pokemon_dto.freezed.dart
+++ b/packages/data/lib/src/services/pokemon/model/pokemon_dto.freezed.dart
@@ -1,0 +1,172 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'pokemon_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PokemonDto {
+  String get name;
+  String get url;
+
+  /// Create a copy of PokemonDto
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $PokemonDtoCopyWith<PokemonDto> get copyWith =>
+      _$PokemonDtoCopyWithImpl<PokemonDto>(this as PokemonDto, _$identity);
+
+  /// Serializes this PokemonDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is PokemonDto &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, name, url);
+
+  @override
+  String toString() {
+    return 'PokemonDto(name: $name, url: $url)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $PokemonDtoCopyWith<$Res> {
+  factory $PokemonDtoCopyWith(
+          PokemonDto value, $Res Function(PokemonDto) _then) =
+      _$PokemonDtoCopyWithImpl;
+  @useResult
+  $Res call({String name, String url});
+}
+
+/// @nodoc
+class _$PokemonDtoCopyWithImpl<$Res> implements $PokemonDtoCopyWith<$Res> {
+  _$PokemonDtoCopyWithImpl(this._self, this._then);
+
+  final PokemonDto _self;
+  final $Res Function(PokemonDto) _then;
+
+  /// Create a copy of PokemonDto
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = null,
+    Object? url = null,
+  }) {
+    return _then(_self.copyWith(
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _self.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _PokemonDto implements PokemonDto {
+  const _PokemonDto({required this.name, required this.url});
+  factory _PokemonDto.fromJson(Map<String, dynamic> json) =>
+      _$PokemonDtoFromJson(json);
+
+  @override
+  final String name;
+  @override
+  final String url;
+
+  /// Create a copy of PokemonDto
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$PokemonDtoCopyWith<_PokemonDto> get copyWith =>
+      __$PokemonDtoCopyWithImpl<_PokemonDto>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$PokemonDtoToJson(
+      this,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _PokemonDto &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.url, url) || other.url == url));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, name, url);
+
+  @override
+  String toString() {
+    return 'PokemonDto(name: $name, url: $url)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$PokemonDtoCopyWith<$Res>
+    implements $PokemonDtoCopyWith<$Res> {
+  factory _$PokemonDtoCopyWith(
+          _PokemonDto value, $Res Function(_PokemonDto) _then) =
+      __$PokemonDtoCopyWithImpl;
+  @override
+  @useResult
+  $Res call({String name, String url});
+}
+
+/// @nodoc
+class __$PokemonDtoCopyWithImpl<$Res> implements _$PokemonDtoCopyWith<$Res> {
+  __$PokemonDtoCopyWithImpl(this._self, this._then);
+
+  final _PokemonDto _self;
+  final $Res Function(_PokemonDto) _then;
+
+  /// Create a copy of PokemonDto
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? name = null,
+    Object? url = null,
+  }) {
+    return _then(_PokemonDto(
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      url: null == url
+          ? _self.url
+          : url // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/data/lib/src/services/pokemon/model/pokemon_dto.freezed.dart
+++ b/packages/data/lib/src/services/pokemon/model/pokemon_dto.freezed.dart
@@ -86,8 +86,8 @@ class _$PokemonDtoCopyWithImpl<$Res> implements $PokemonDtoCopyWith<$Res> {
 
 /// @nodoc
 @JsonSerializable()
-class _PokemonDto implements PokemonDto {
-  const _PokemonDto({required this.name, required this.url});
+class _PokemonDto extends PokemonDto {
+  const _PokemonDto({required this.name, required this.url}) : super._();
   factory _PokemonDto.fromJson(Map<String, dynamic> json) =>
       _$PokemonDtoFromJson(json);
 

--- a/packages/data/lib/src/services/pokemon/model/pokemon_dto.g.dart
+++ b/packages/data/lib/src/services/pokemon/model/pokemon_dto.g.dart
@@ -1,0 +1,18 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pokemon_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_PokemonDto _$PokemonDtoFromJson(Map<String, dynamic> json) => _PokemonDto(
+      name: json['name'] as String,
+      url: json['url'] as String,
+    );
+
+Map<String, dynamic> _$PokemonDtoToJson(_PokemonDto instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'url': instance.url,
+    };

--- a/packages/data/lib/src/services/pokemon/pokemon_service.dart
+++ b/packages/data/lib/src/services/pokemon/pokemon_service.dart
@@ -1,0 +1,50 @@
+import 'package:dio/dio.dart';
+import 'package:domain/src/core/result/result.dart';
+
+import '../../core/errors/data_failure.dart';
+import '../api/api_client.dart';
+import 'model/pokemon_dto.dart';
+
+/// Pokemon に関する API 通信を担当するサービス。
+class PokemonService {
+  PokemonService(this._apiClient);
+
+  final ApiClient _apiClient;
+
+  /// ポケモン一覧を取得する。
+  Future<Result<List<PokemonDto>, DataFailure>> fetchPokemons({
+    int limit = 20,
+    int offset = 0,
+  }) async {
+    try {
+      final response = await _apiClient.get<Map<String, dynamic>>(
+        '/pokemon',
+        queryParameters: {
+          'limit': limit,
+          'offset': offset,
+        },
+      );
+
+      final data = response.data;
+      if (data == null) {
+        return Failure<List<PokemonDto>, DataFailure>(
+          const DataFailure.emptyResponse(message: 'No data'),
+        );
+      }
+
+      final results = data['results'] as List<dynamic>;
+      final pokemons = results
+          .map((e) => PokemonDto.fromJson(e as Map<String, dynamic>))
+          .toList();
+      return Success<List<PokemonDto>, DataFailure>(pokemons);
+    } on DioException catch (e) {
+      return Failure<List<PokemonDto>, DataFailure>(
+        DataFailure.network(message: e.message ?? 'Network error'),
+      );
+    } catch (e) {
+      return Failure<List<PokemonDto>, DataFailure>(
+        DataFailure.unexpected(message: e.toString()),
+      );
+    }
+  }
+}

--- a/packages/data/pubspec.yaml
+++ b/packages/data/pubspec.yaml
@@ -23,6 +23,17 @@ dependencies:
 
   # The domain layer will be added as a dependency once created.
 
+  # External HTTP client
+  dio: ^5.4.0
+
+  # JSON serialization / immutable classes
+  freezed_annotation: ^3.0.0
+  json_annotation: ^4.8.1
+
+  # Domain layer dependency
+  domain:
+    path: ../domain
+
   # Riverpod code generation annotations
   riverpod_annotation: ^2.3.4
 
@@ -39,3 +50,7 @@ dev_dependencies:
   riverpod_generator: ^2.3.4
   custom_lint:
   riverpod_lint: ^2.3.4
+
+  # Freezed & JSON Serializable
+  freezed: ^3.0.6
+  json_serializable: ^6.8.0

--- a/packages/data/test/pokemon_dto_test.dart
+++ b/packages/data/test/pokemon_dto_test.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+import 'package:data/src/services/pokemon/model/pokemon_dto.dart';
+
+void main() {
+  test('PokemonDto can be created', () {
+    final dto = PokemonDto(name: 'pikachu', url: 'https://pokeapi.co/api/v2/pokemon/25/');
+    expect(dto.name, 'pikachu');
+    expect(dto.url, 'https://pokeapi.co/api/v2/pokemon/25/');
+  });
+
+  test('PokemonDto can be serialized from JSON', () {
+    final json = {
+      'name': 'pikachu',
+      'url': 'https://pokeapi.co/api/v2/pokemon/25/',
+    };
+    final dto = PokemonDto.fromJson(json);
+    expect(dto.name, 'pikachu');
+    expect(dto.url, 'https://pokeapi.co/api/v2/pokemon/25/');
+  });
+
+  test('PokemonDto can be serialized to JSON', () {
+    final dto = PokemonDto(name: 'pikachu', url: 'https://pokeapi.co/api/v2/pokemon/25/');
+    final json = dto.toJson();
+    expect(json['name'], 'pikachu');
+    expect(json['url'], 'https://pokeapi.co/api/v2/pokemon/25/');
+  });
+}

--- a/packages/data/test/pokemon_service_test.dart
+++ b/packages/data/test/pokemon_service_test.dart
@@ -1,0 +1,27 @@
+import 'package:data/src/services/api/api_client.dart';
+import 'package:data/src/services/pokemon/pokemon_service.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PokemonService', () {
+    late PokemonService service;
+
+    setUp(() {
+      final dio = Dio(BaseOptions(baseUrl: 'https://pokeapi.co/api/v2'));
+      final apiClient = ApiClient(dio: dio);
+      service = PokemonService(apiClient);
+    });
+
+    test('fetchPokemons returns list of pokemons', () async {
+      final result = await service.fetchPokemons(limit: 1);
+      result.when(
+        success: (pokemons) {
+          expect(pokemons, isNotEmpty);
+        },
+        failure: (failure) =>
+            fail('Expected success, got failure: ${failure.toString()}'),
+      );
+    });
+  });
+}

--- a/packages/domain/lib/src/core/result/result.dart
+++ b/packages/domain/lib/src/core/result/result.dart
@@ -1,0 +1,38 @@
+/// A simple Result type representing either a [Success] with value [S]
+/// or a [Failure] with error [F].
+sealed class Result<S, F> {
+  const Result();
+
+  /// Pattern matching utility to handle both branches.
+  T when<T>(
+      {required T Function(S data) success,
+      required T Function(F failure) failure});
+}
+
+/// Represents a successful result containing [value].
+class Success<S, F> extends Result<S, F> {
+  const Success(this.value);
+
+  final S value;
+
+  @override
+  T when<T>(
+      {required T Function(S data) success,
+      required T Function(F failure) failure}) {
+    return success(value);
+  }
+}
+
+/// Represents a failed result containing [failure].
+class Failure<S, F> extends Result<S, F> {
+  const Failure(this.failure);
+
+  final F failure;
+
+  @override
+  T when<T>(
+      {required T Function(S data) success,
+      required T Function(F failure) failure}) {
+    return failure(this.failure);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -265,6 +265,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: "253a18bbd4851fecba42f7343a1df3a9a4c1d31a2c1b37e221086b4fa8c8dbc9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.8.0+1"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   drift:
     dependency: transitive
     description:
@@ -456,6 +472,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.9.0"
+  json_serializable:
+    dependency: transitive
+    description:
+      name: json_serializable
+      sha256: c50ef5fc083d5b5e12eef489503ba3bf5ccc899e487d691584699b4bdefeea8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.9.5"
   leak_tracker:
     dependency: transitive
     description:
@@ -757,6 +781,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      sha256: "86d247119aedce8e63f4751bd9626fc9613255935558447569ad42f9f5b48b3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.5"
   source_map_stack_trace:
     dependency: transitive
     description:


### PR DESCRIPTION
## 対応する Issue

Closes #4

## リンク

- [PokeAPI Documentation](https://pokeapi.co/docs/v2)
- [Freezed Documentation](https://pub.dev/packages/freezed)

## やったこと

- PokeAPI との通信を行う ApiClient を実装
- freezed を使用した型安全な PokemonDTO を実装
- Result 型を使用したエラーハンドリングを含む PokemonService を実装
- freezed 3.0.6 でのコンパイルエラー問題を解決（abstract class パターンの適用）
- 基本的なユニットテストを追加し、API通信とDTO serialization を検証
- CLAUDE.md ファイルを作成し、今後の開発者向けガイドを整備
- dio, freezed_annotation 等の必要な依存関係を data パッケージに設定

## やらなかったこと

- 個別Pokemon詳細API（/pokemon/{id}）の実装
- 画像URL、タイプ、ステータス等の詳細情報DTO拡張
- Riverpod Provider の実装
- ローカルデータベースとの統合
- 進化チェーンAPIの対応

## ユーザーへの影響

- 開発者がPokeAPIからPokemonデータを取得できるようになりました
- データ層の基盤が整備され、今後のUI機能実装の準備が完了しました
- エンドユーザーには直接的な影響はありません（データ層のみの実装）

## 動作確認

### 確認した環境

- macOS (開発環境)
- Dart VM (テスト実行)

### 確認したこと

- ✅ PokemonDTO の作成、JSON serialization/deserialization
- ✅ ApiClient による PokeAPI への GET リクエスト
- ✅ PokemonService.fetchPokemons() の正常動作
- ✅ Result 型によるエラーハンドリング
- ✅ freezed によるコード生成の正常動作
- ✅ 全ユニットテスト（7個）の実行成功

```bash
✅ PokemonDto can be created
✅ PokemonDto can be serialized from JSON  
✅ PokemonDto can be serialized to JSON
✅ PokemonService fetchPokemons returns list of pokemons
```

### 確認しなかった（できなかった）こと

- 実機での動作確認（UI層未実装のため）
- パフォーマンステスト
- エラー境界値でのテスト

## その他

### 技術的な解決事項

**Freezed コンパイルエラーの解決**
- **問題**: freezed で生成されたコードがコンパイルエラーを起こしていた
- **原因**: freezed 3.0.6 では、単一factory constructorのクラスも `abstract class` にする必要があった
- **解決**: `class PokemonDto` → `abstract class PokemonDto` に変更

### コミット履歴

- `adf11a3` feat: #4 データ層 (PokeAPI) のセットアップを完了
- `effcc12` feat: #4 データ層 PokeAPI セットアップ ✨

### 今後の発展

この実装により、以下の機能開発の基盤が整いました：
- PokedexページでのPokemon一覧表示
- 個別Pokemon詳細情報の取得
- パーティ管理機能でのPokemonデータ活用