### PR TITLE
feat: #5 ポケモン図鑑の無限スクロールリスト表示を実装

### DIFF
--- a/packages/app/pubspec.yaml
+++ b/packages/app/pubspec.yaml
@@ -12,8 +12,13 @@ dependencies:
     sdk: flutter
   design_system:
     path: ../design_system
+  domain:
+    path: ../domain
   flutter_riverpod: ^2.6.1
   go_router: ^15.2.0
+  flutter_hooks: ^0.21.2
+  hooks_riverpod: ^2.6.1
+  cached_network_image: ^3.3.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/domain/lib/domain.dart
+++ b/packages/domain/lib/domain.dart
@@ -4,3 +4,7 @@
 library domain;
 
 export 'src/core/core.dart';
+
+// Features
+export 'src/features/pokemon/pokemon.dart';
+export 'src/features/pokemon/pokemon_state.dart';

--- a/packages/domain/lib/src/core/core.dart
+++ b/packages/domain/lib/src/core/core.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_element
+/// Core domain utilities.
+library core;
 
-/// Placeholder for domain core utilities.
-class _PlaceholderDomainCore {}
+export 'result/result.dart';

--- a/packages/domain/lib/src/features/pokemon/pokemon.dart
+++ b/packages/domain/lib/src/features/pokemon/pokemon.dart
@@ -1,0 +1,31 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'pokemon.freezed.dart';
+
+/// Pokemon エンティティ。図鑑での表示に必要な情報を持つ。
+@freezed
+abstract class Pokemon with _$Pokemon {
+  const Pokemon._();
+
+  const factory Pokemon({
+    /// PokeAPI から取得される ID（例: 1, 25, 151）
+    required int id,
+    
+    /// Pokemon 名（英語）
+    required String name,
+    
+    /// 図鑑番号（通常は id と同じ）
+    required int pokedexNumber,
+    
+    /// スプライト画像URL
+    required String imageUrl,
+  }) = _Pokemon;
+
+  /// 図鑑番号を #001 形式でフォーマットする。
+  String get formattedPokedexNumber => '#${pokedexNumber.toString().padLeft(3, '0')}';
+
+  /// Pokemon名の最初の文字を大文字にしたもの。
+  String get displayName => name.isNotEmpty 
+      ? name[0].toUpperCase() + name.substring(1).toLowerCase()
+      : name;
+}

--- a/packages/domain/lib/src/features/pokemon/pokemon.freezed.dart
+++ b/packages/domain/lib/src/features/pokemon/pokemon.freezed.dart
@@ -1,0 +1,210 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'pokemon.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$Pokemon {
+  /// PokeAPI から取得される ID（例: 1, 25, 151）
+  int get id;
+
+  /// Pokemon 名（英語）
+  String get name;
+
+  /// 図鑑番号（通常は id と同じ）
+  int get pokedexNumber;
+
+  /// スプライト画像URL
+  String get imageUrl;
+
+  /// Create a copy of Pokemon
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $PokemonCopyWith<Pokemon> get copyWith =>
+      _$PokemonCopyWithImpl<Pokemon>(this as Pokemon, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is Pokemon &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.pokedexNumber, pokedexNumber) ||
+                other.pokedexNumber == pokedexNumber) &&
+            (identical(other.imageUrl, imageUrl) ||
+                other.imageUrl == imageUrl));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, name, pokedexNumber, imageUrl);
+
+  @override
+  String toString() {
+    return 'Pokemon(id: $id, name: $name, pokedexNumber: $pokedexNumber, imageUrl: $imageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $PokemonCopyWith<$Res> {
+  factory $PokemonCopyWith(Pokemon value, $Res Function(Pokemon) _then) =
+      _$PokemonCopyWithImpl;
+  @useResult
+  $Res call({int id, String name, int pokedexNumber, String imageUrl});
+}
+
+/// @nodoc
+class _$PokemonCopyWithImpl<$Res> implements $PokemonCopyWith<$Res> {
+  _$PokemonCopyWithImpl(this._self, this._then);
+
+  final Pokemon _self;
+  final $Res Function(Pokemon) _then;
+
+  /// Create a copy of Pokemon
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? pokedexNumber = null,
+    Object? imageUrl = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      pokedexNumber: null == pokedexNumber
+          ? _self.pokedexNumber
+          : pokedexNumber // ignore: cast_nullable_to_non_nullable
+              as int,
+      imageUrl: null == imageUrl
+          ? _self.imageUrl
+          : imageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _Pokemon extends Pokemon {
+  const _Pokemon(
+      {required this.id,
+      required this.name,
+      required this.pokedexNumber,
+      required this.imageUrl})
+      : super._();
+
+  /// PokeAPI から取得される ID（例: 1, 25, 151）
+  @override
+  final int id;
+
+  /// Pokemon 名（英語）
+  @override
+  final String name;
+
+  /// 図鑑番号（通常は id と同じ）
+  @override
+  final int pokedexNumber;
+
+  /// スプライト画像URL
+  @override
+  final String imageUrl;
+
+  /// Create a copy of Pokemon
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$PokemonCopyWith<_Pokemon> get copyWith =>
+      __$PokemonCopyWithImpl<_Pokemon>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _Pokemon &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.pokedexNumber, pokedexNumber) ||
+                other.pokedexNumber == pokedexNumber) &&
+            (identical(other.imageUrl, imageUrl) ||
+                other.imageUrl == imageUrl));
+  }
+
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, id, name, pokedexNumber, imageUrl);
+
+  @override
+  String toString() {
+    return 'Pokemon(id: $id, name: $name, pokedexNumber: $pokedexNumber, imageUrl: $imageUrl)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$PokemonCopyWith<$Res> implements $PokemonCopyWith<$Res> {
+  factory _$PokemonCopyWith(_Pokemon value, $Res Function(_Pokemon) _then) =
+      __$PokemonCopyWithImpl;
+  @override
+  @useResult
+  $Res call({int id, String name, int pokedexNumber, String imageUrl});
+}
+
+/// @nodoc
+class __$PokemonCopyWithImpl<$Res> implements _$PokemonCopyWith<$Res> {
+  __$PokemonCopyWithImpl(this._self, this._then);
+
+  final _Pokemon _self;
+  final $Res Function(_Pokemon) _then;
+
+  /// Create a copy of Pokemon
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? name = null,
+    Object? pokedexNumber = null,
+    Object? imageUrl = null,
+  }) {
+    return _then(_Pokemon(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      name: null == name
+          ? _self.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String,
+      pokedexNumber: null == pokedexNumber
+          ? _self.pokedexNumber
+          : pokedexNumber // ignore: cast_nullable_to_non_nullable
+              as int,
+      imageUrl: null == imageUrl
+          ? _self.imageUrl
+          : imageUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/domain/lib/src/features/pokemon/pokemon_state.dart
+++ b/packages/domain/lib/src/features/pokemon/pokemon_state.dart
@@ -1,0 +1,77 @@
+import 'package:data/src/services/api/api_client.dart';
+import 'package:data/src/services/pokemon/pokemon_service.dart';
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../../core/result/result.dart';
+import 'pokemon.dart';
+
+part 'pokemon_state.g.dart';
+
+/// Pokemon 一覧の状態を管理するクラス。無限スクロール対応。
+@riverpod
+class PokemonState extends _$PokemonState {
+  static const int _pageSize = 20;
+
+  @override
+  List<Pokemon> build() {
+    return [];
+  }
+
+  /// Pokemon 一覧を初期読み込みする。
+  Future<void> fetchInitialPokemons() async {
+    state = [];
+    await _fetchPokemons(offset: 0);
+  }
+
+  /// 次のページの Pokemon 一覧を読み込む。
+  Future<void> fetchNextPage() async {
+    final currentOffset = state.length;
+    await _fetchPokemons(offset: currentOffset);
+  }
+
+  /// 指定されたオフセットから Pokemon 一覧を取得する。
+  Future<void> _fetchPokemons({required int offset}) async {
+    final pokemonService = ref.read(pokemonServiceProvider);
+    
+    final result = await pokemonService.fetchPokemons(
+      limit: _pageSize,
+      offset: offset,
+    );
+
+    result.when(
+      success: (pokemonDtos) {
+        final newPokemons = pokemonDtos.map(_convertToEntity).toList();
+        state = [...state, ...newPokemons];
+      },
+      failure: (failure) {
+        // エラーハンドリングは上位層に委譲
+        throw Exception('Failed to fetch pokemons: ${failure.toString()}');
+      },
+    );
+  }
+
+  /// PokemonDTO を Pokemon エンティティに変換する。
+  Pokemon _convertToEntity(pokemonDto) {
+    // URLから ID を抽出（例: "https://pokeapi.co/api/v2/pokemon/25/" -> 25）
+    final urlParts = pokemonDto.url.split('/');
+    final idString = urlParts[urlParts.length - 2]; // 最後の '/' を除いた要素
+    final id = int.tryParse(idString) ?? 0;
+    
+    // スプライト画像URLを生成
+    final imageUrl = 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/$id.png';
+    
+    return Pokemon(
+      id: id,
+      name: pokemonDto.name,
+      pokedexNumber: id, // 通常、ID と図鑑番号は同じ
+      imageUrl: imageUrl,
+    );
+  }
+}
+
+/// PokemonService の Provider を定義。
+@riverpod
+PokemonService pokemonService(PokemonServiceRef ref) {
+  final apiClient = ApiClient();
+  return PokemonService(apiClient);
+}

--- a/packages/domain/lib/src/features/pokemon/pokemon_state.dart
+++ b/packages/domain/lib/src/features/pokemon/pokemon_state.dart
@@ -2,7 +2,6 @@ import 'package:data/src/services/api/api_client.dart';
 import 'package:data/src/services/pokemon/pokemon_service.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
-import '../../core/result/result.dart';
 import 'pokemon.dart';
 
 part 'pokemon_state.g.dart';
@@ -71,7 +70,7 @@ class PokemonState extends _$PokemonState {
 
 /// PokemonService の Provider を定義。
 @riverpod
-PokemonService pokemonService(PokemonServiceRef ref) {
+PokemonService pokemonService(ref) {
   final apiClient = ApiClient();
   return PokemonService(apiClient);
 }

--- a/packages/domain/lib/src/features/pokemon/pokemon_state.g.dart
+++ b/packages/domain/lib/src/features/pokemon/pokemon_state.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pokemon_state.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$pokemonServiceHash() => r'74dc99abe6b1b7ae878e7123efaba417439accff';
+
+/// PokemonService の Provider を定義。
+///
+/// Copied from [pokemonService].
+@ProviderFor(pokemonService)
+final pokemonServiceProvider = AutoDisposeProvider<PokemonService>.internal(
+  pokemonService,
+  name: r'pokemonServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$pokemonServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef PokemonServiceRef = AutoDisposeProviderRef<PokemonService>;
+String _$pokemonStateHash() => r'869465b74c4364f7e7be27bcfd995cdb6fb9e844';
+
+/// Pokemon 一覧の状態を管理するクラス。無限スクロール対応。
+///
+/// Copied from [PokemonState].
+@ProviderFor(PokemonState)
+final pokemonStateProvider =
+    AutoDisposeNotifierProvider<PokemonState, List<Pokemon>>.internal(
+  PokemonState.new,
+  name: r'pokemonStateProvider',
+  debugGetCreateSourceHash:
+      const bool.fromEnvironment('dart.vm.product') ? null : _$pokemonStateHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$PokemonState = AutoDisposeNotifier<List<Pokemon>>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/domain/pubspec.yaml
+++ b/packages/domain/pubspec.yaml
@@ -10,6 +10,13 @@ resolution: workspace
 dependencies:
   meta: ^1.12.0
   freezed_annotation: ^3.0.0
+  
+  # Riverpod for state management
+  riverpod_annotation: ^2.3.4
+  
+  # Data layer dependency
+  data:
+    path: ../data
 
 dev_dependencies:
   build_runner: ^2.4.0
@@ -17,3 +24,6 @@ dev_dependencies:
   flutter_lints: ^5.0.0
   very_good_analysis: ^7.0.0
   test: ^1.25.0
+  
+  # Riverpod code generation
+  riverpod_generator: ^2.3.4

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.10.1"
+  cached_network_image:
+    dependency: transitive
+    description:
+      name: cached_network_image
+      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -334,6 +358,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
+  flutter_hooks:
+    dependency: transitive
+    description:
+      name: flutter_hooks
+      sha256: b772e710d16d7a20c0740c4f855095026b31c7eb5ba3ab67d2bd52021cd9461d
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.21.2"
   flutter_lints:
     dependency: transitive
     description:
@@ -408,6 +448,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  hooks_riverpod:
+    dependency: transitive
+    description:
+      name: hooks_riverpod
+      sha256: "70bba33cfc5670c84b796e6929c54b8bc5be7d0fe15bb28c2560500b9ad06966"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   hotreloader:
     dependency: transitive
     description:
@@ -568,6 +616,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -821,6 +877,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.5"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   sqlite3:
     dependency: transitive
     description:
@@ -885,6 +981,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:


### PR DESCRIPTION
$(cat <<'EOF'
## 対応する Issue

Closes #5

## リンク

- PokeAPI sprites: https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/

## やったこと

- ポケモン図鑑画面をGridViewからListViewに変更
- 無限スクロール機能を実装（20件ずつページネーション）
- cached_network_imageを使用したポケモン画像の表示
- domainレイヤーにPokemonエンティティとPokemonStateを追加
- PokemonServiceとの連携によるPokeAPIからのデータ取得
- Riverpodを使用した状態管理の実装
- Flutter Hooksを使用したスクロール制御
- エラーハンドリングとローディング状態の表示

## やらなかったこと

- 地方別フィルター機能の実装（TODO として残存）
- ポケモン詳細画面への遷移（TODO として残存）
- パーティーへの追加機能（TODO として残存）
- 検索機能の実装

## ユーザーへの影響

- ポケモン図鑑でリアルなポケモンデータ（名前、画像、図鑑番号）が表示されるようになった
- スムーズな無限スクロールでポケモン一覧を閲覧できるようになった
- ポケモン画像がキャッシュされ、パフォーマンスが向上した
- ListView形式により視認性が向上した

## 動作確認

### 確認した環境

- macOS 14.5.0 (Darwin 24.5.0)
- Flutter 3.32.2 (fvm管理)

### 確認したこと

- ポケモン一覧の初期表示（最初の20件）
- 無限スクロールによる追加データの読み込み
- ポケモン画像の表示とキャッシュ機能
- ローディングインジケーターの表示
- エラー時のフォールバック画像表示
- Riverpodでの状態管理が正常に動作
- Flutter analyzeでの静的解析（警告なし）

### 確認しなかった（できなかった）こと

- 実機での動作確認
- 地方別フィルター機能（未実装）
- ポケモンの詳細画面への遷移
- パーティーへの追加機能

## その他

- Clean Architectureパターンに準拠した実装
- fvmを使用したFlutter version管理に対応
- analyzer警告の修正（unused import、deprecated API）
- CLAUDE.mdの更新（fvm使用の記載追加）

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)