### PR TITLE
feat: Issue #10 育成カウンター機能の実装

### DIFF
--- a/packages/app/lib/pages/party_page.dart
+++ b/packages/app/lib/pages/party_page.dart
@@ -62,25 +62,25 @@ class PartyPage extends HookConsumerWidget {
                         itemBuilder: (context, index) {
                           if (index < partySlots.length) {
                             final slot = partySlots[index];
-                            return slot.when(
-                              filled: (partyPokemonId, pokemonId, position, breedingCounter) {
-                                final pokemon = allPokemons.where((p) => p.id == pokemonId).firstOrNull;
-                                return _PokemonCard(
-                                  pokemon: pokemon,
-                                  partyPokemonId: partyPokemonId,
-                                  breedingCounter: breedingCounter,
-                                  canEvolve: slot.canEvolve,
-                                  progressPercentage: slot.progressPercentage,
-                                  onTap: pokemon != null ? () => _showPokemonOptions(context, ref, pokemon) : null,
-                                  onLongPress: pokemon != null ? () => _showDeleteDialog(context, ref, pokemon) : null,
-                                  onIncrementCounter: () => _incrementCounter(ref, partyPokemonId),
-                                  onDecrementCounter: () => _decrementCounter(ref, partyPokemonId),
-                                );
-                              },
-                              empty: (position) => _EmptySlotCard(
+                            if (slot.runtimeType.toString().contains('Filled')) {
+                              final filled = slot as dynamic;
+                              final pokemon = allPokemons.where((p) => p.id == filled.pokemonId).firstOrNull;
+                              return _PokemonCard(
+                                pokemon: pokemon,
+                                partyPokemonId: filled.partyPokemonId,
+                                breedingCounter: filled.breedingCounter,
+                                canEvolve: slot.canEvolve,
+                                progressPercentage: slot.progressPercentage,
+                                onTap: pokemon != null ? () => _showPokemonOptions(context, ref, pokemon) : null,
+                                onLongPress: pokemon != null ? () => _showDeleteDialog(context, ref, pokemon) : null,
+                                onIncrementCounter: () => _incrementCounter(ref, filled.partyPokemonId),
+                                onDecrementCounter: () => _decrementCounter(ref, filled.partyPokemonId),
+                              );
+                            } else {
+                              return _EmptySlotCard(
                                 onTap: () => context.go('/pokedex'),
-                              ),
-                            );
+                              );
+                            }
                           } else {
                             return _EmptySlotCard(
                               onTap: () => context.go('/pokedex'),

--- a/packages/data/lib/src/services/local_storage/database.dart
+++ b/packages/data/lib/src/services/local_storage/database.dart
@@ -21,6 +21,31 @@ class Parties extends Table {
   DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
 }
 
+/// パーティ内ポケモンテーブル定義（育成カウンター情報を含む）
+class PartyPokemons extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  /// パーティID（外部キー）
+  IntColumn get partyId => integer().references(Parties, #id)();
+
+  /// ポケモンID
+  IntColumn get pokemonId => integer()();
+
+  /// パーティ内での位置（0-5）
+  IntColumn get position => integer().check(position.isBetweenValues(0, 5))();
+
+  /// 育成カウンター
+  IntColumn get breedingCounter => integer().withDefault(const Constant(0))();
+
+  DateTimeColumn get createdAt => dateTime().withDefault(currentDateAndTime)();
+  DateTimeColumn get updatedAt => dateTime().withDefault(currentDateAndTime)();
+
+  @override
+  List<Set<Column>> get uniqueKeys => [
+    {partyId, position}, // パーティ内での位置は一意
+  ];
+}
+
 class _StringListConverter extends TypeConverter<List<String>, String> {
   const _StringListConverter();
 
@@ -34,12 +59,48 @@ class _StringListConverter extends TypeConverter<List<String>, String> {
   String toSql(List<String> value) => value.join(',');
 }
 
-@DriftDatabase(tables: [Parties])
+@DriftDatabase(tables: [Parties, PartyPokemons])
 class LocalDatabase extends _$LocalDatabase {
   LocalDatabase() : super(_openConnection());
 
   @override
-  int get schemaVersion => 1;
+  int get schemaVersion => 2;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (Migrator m) async {
+      await m.createAll();
+    },
+    onUpgrade: (Migrator m, int from, int to) async {
+      if (from < 2) {
+        // v1 -> v2: PartyPokemonsテーブルを追加
+        await m.createTable(partyPokemons);
+        
+        // 既存のパーティデータをPartyPokemonsテーブルに移行
+        await _migratePartyData();
+      }
+    },
+  );
+
+  /// 既存のパーティデータをPartyPokemonsテーブルに移行する。
+  Future<void> _migratePartyData() async {
+    final existingParties = await select(parties).get();
+    
+    for (final party in existingParties) {
+      final pokemonIds = party.pokemonIds;
+      for (int i = 0; i < pokemonIds.length && i < 6; i++) {
+        final pokemonId = int.tryParse(pokemonIds[i]);
+        if (pokemonId != null) {
+          await into(partyPokemons).insert(PartyPokemonsCompanion.insert(
+            partyId: party.id,
+            pokemonId: pokemonId,
+            position: i,
+            breedingCounter: const Value(0),
+          ));
+        }
+      }
+    }
+  }
 
   // CRUD convenience methods -------------------------------------------------
   Future<int> insertParty(PartiesCompanion companion) =>
@@ -51,6 +112,34 @@ class LocalDatabase extends _$LocalDatabase {
 
   Future<int> deleteParty(int id) =>
       (delete(parties)..where((tbl) => tbl.id.equals(id))).go();
+
+  // PartyPokemons CRUD methods -----------------------------------------------
+  Future<List<PartyPokemon>> getPartyPokemons(int partyId) =>
+      (select(partyPokemons)..where((tbl) => tbl.partyId.equals(partyId))
+        ..orderBy([(tbl) => OrderingTerm.asc(tbl.position)])).get();
+
+  Future<int> insertPartyPokemon(PartyPokemonsCompanion companion) =>
+      into(partyPokemons).insert(companion);
+
+  Future<bool> updatePartyPokemon(PartyPokemon partyPokemon) =>
+      update(partyPokemons).replace(partyPokemon);
+
+  Future<int> deletePartyPokemon(int id) =>
+      (delete(partyPokemons)..where((tbl) => tbl.id.equals(id))).go();
+
+  Future<int> deletePartyPokemonsByPartyId(int partyId) =>
+      (delete(partyPokemons)..where((tbl) => tbl.partyId.equals(partyId))).go();
+
+  /// 育成カウンターを更新する。
+  Future<bool> updateBreedingCounter(int partyPokemonId, int counter) async {
+    final result = await (update(partyPokemons)
+          ..where((tbl) => tbl.id.equals(partyPokemonId)))
+        .write(PartyPokemonsCompanion(
+      breedingCounter: Value(counter),
+      updatedAt: Value(DateTime.now()),
+    ));
+    return result > 0;
+  }
 }
 
 LazyDatabase _openConnection() {

--- a/packages/data/lib/src/services/local_storage/database.g.dart
+++ b/packages/data/lib/src/services/local_storage/database.g.dart
@@ -307,15 +307,408 @@ class PartiesCompanion extends UpdateCompanion<Party> {
   }
 }
 
+class $PartyPokemonsTable extends PartyPokemons
+    with TableInfo<$PartyPokemonsTable, PartyPokemon> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PartyPokemonsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+      'id', aliasedName, false,
+      hasAutoIncrement: true,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('PRIMARY KEY AUTOINCREMENT'));
+  static const VerificationMeta _partyIdMeta =
+      const VerificationMeta('partyId');
+  @override
+  late final GeneratedColumn<int> partyId = GeneratedColumn<int>(
+      'party_id', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: true,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('REFERENCES parties (id)'));
+  static const VerificationMeta _pokemonIdMeta =
+      const VerificationMeta('pokemonId');
+  @override
+  late final GeneratedColumn<int> pokemonId = GeneratedColumn<int>(
+      'pokemon_id', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _positionMeta =
+      const VerificationMeta('position');
+  @override
+  late final GeneratedColumn<int> position = GeneratedColumn<int>(
+      'position', aliasedName, false,
+      check: () => ComparableExpr(position).isBetweenValues(0, 5),
+      type: DriftSqlType.int,
+      requiredDuringInsert: true);
+  static const VerificationMeta _breedingCounterMeta =
+      const VerificationMeta('breedingCounter');
+  @override
+  late final GeneratedColumn<int> breedingCounter = GeneratedColumn<int>(
+      'breeding_counter', aliasedName, false,
+      type: DriftSqlType.int,
+      requiredDuringInsert: false,
+      defaultValue: const Constant(0));
+  static const VerificationMeta _createdAtMeta =
+      const VerificationMeta('createdAt');
+  @override
+  late final GeneratedColumn<DateTime> createdAt = GeneratedColumn<DateTime>(
+      'created_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  static const VerificationMeta _updatedAtMeta =
+      const VerificationMeta('updatedAt');
+  @override
+  late final GeneratedColumn<DateTime> updatedAt = GeneratedColumn<DateTime>(
+      'updated_at', aliasedName, false,
+      type: DriftSqlType.dateTime,
+      requiredDuringInsert: false,
+      defaultValue: currentDateAndTime);
+  @override
+  List<GeneratedColumn> get $columns =>
+      [id, partyId, pokemonId, position, breedingCounter, createdAt, updatedAt];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'party_pokemons';
+  @override
+  VerificationContext validateIntegrity(Insertable<PartyPokemon> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('party_id')) {
+      context.handle(_partyIdMeta,
+          partyId.isAcceptableOrUnknown(data['party_id']!, _partyIdMeta));
+    } else if (isInserting) {
+      context.missing(_partyIdMeta);
+    }
+    if (data.containsKey('pokemon_id')) {
+      context.handle(_pokemonIdMeta,
+          pokemonId.isAcceptableOrUnknown(data['pokemon_id']!, _pokemonIdMeta));
+    } else if (isInserting) {
+      context.missing(_pokemonIdMeta);
+    }
+    if (data.containsKey('position')) {
+      context.handle(_positionMeta,
+          position.isAcceptableOrUnknown(data['position']!, _positionMeta));
+    } else if (isInserting) {
+      context.missing(_positionMeta);
+    }
+    if (data.containsKey('breeding_counter')) {
+      context.handle(
+          _breedingCounterMeta,
+          breedingCounter.isAcceptableOrUnknown(
+              data['breeding_counter']!, _breedingCounterMeta));
+    }
+    if (data.containsKey('created_at')) {
+      context.handle(_createdAtMeta,
+          createdAt.isAcceptableOrUnknown(data['created_at']!, _createdAtMeta));
+    }
+    if (data.containsKey('updated_at')) {
+      context.handle(_updatedAtMeta,
+          updatedAt.isAcceptableOrUnknown(data['updated_at']!, _updatedAtMeta));
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  List<Set<GeneratedColumn>> get uniqueKeys => [
+        {partyId, position},
+      ];
+  @override
+  PartyPokemon map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return PartyPokemon(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}id'])!,
+      partyId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}party_id'])!,
+      pokemonId: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}pokemon_id'])!,
+      position: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}position'])!,
+      breedingCounter: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}breeding_counter'])!,
+      createdAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}created_at'])!,
+      updatedAt: attachedDatabase.typeMapping
+          .read(DriftSqlType.dateTime, data['${effectivePrefix}updated_at'])!,
+    );
+  }
+
+  @override
+  $PartyPokemonsTable createAlias(String alias) {
+    return $PartyPokemonsTable(attachedDatabase, alias);
+  }
+}
+
+class PartyPokemon extends DataClass implements Insertable<PartyPokemon> {
+  final int id;
+
+  /// パーティID（外部キー）
+  final int partyId;
+
+  /// ポケモンID
+  final int pokemonId;
+
+  /// パーティ内での位置（0-5）
+  final int position;
+
+  /// 育成カウンター
+  final int breedingCounter;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+  const PartyPokemon(
+      {required this.id,
+      required this.partyId,
+      required this.pokemonId,
+      required this.position,
+      required this.breedingCounter,
+      required this.createdAt,
+      required this.updatedAt});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['party_id'] = Variable<int>(partyId);
+    map['pokemon_id'] = Variable<int>(pokemonId);
+    map['position'] = Variable<int>(position);
+    map['breeding_counter'] = Variable<int>(breedingCounter);
+    map['created_at'] = Variable<DateTime>(createdAt);
+    map['updated_at'] = Variable<DateTime>(updatedAt);
+    return map;
+  }
+
+  PartyPokemonsCompanion toCompanion(bool nullToAbsent) {
+    return PartyPokemonsCompanion(
+      id: Value(id),
+      partyId: Value(partyId),
+      pokemonId: Value(pokemonId),
+      position: Value(position),
+      breedingCounter: Value(breedingCounter),
+      createdAt: Value(createdAt),
+      updatedAt: Value(updatedAt),
+    );
+  }
+
+  factory PartyPokemon.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return PartyPokemon(
+      id: serializer.fromJson<int>(json['id']),
+      partyId: serializer.fromJson<int>(json['partyId']),
+      pokemonId: serializer.fromJson<int>(json['pokemonId']),
+      position: serializer.fromJson<int>(json['position']),
+      breedingCounter: serializer.fromJson<int>(json['breedingCounter']),
+      createdAt: serializer.fromJson<DateTime>(json['createdAt']),
+      updatedAt: serializer.fromJson<DateTime>(json['updatedAt']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'partyId': serializer.toJson<int>(partyId),
+      'pokemonId': serializer.toJson<int>(pokemonId),
+      'position': serializer.toJson<int>(position),
+      'breedingCounter': serializer.toJson<int>(breedingCounter),
+      'createdAt': serializer.toJson<DateTime>(createdAt),
+      'updatedAt': serializer.toJson<DateTime>(updatedAt),
+    };
+  }
+
+  PartyPokemon copyWith(
+          {int? id,
+          int? partyId,
+          int? pokemonId,
+          int? position,
+          int? breedingCounter,
+          DateTime? createdAt,
+          DateTime? updatedAt}) =>
+      PartyPokemon(
+        id: id ?? this.id,
+        partyId: partyId ?? this.partyId,
+        pokemonId: pokemonId ?? this.pokemonId,
+        position: position ?? this.position,
+        breedingCounter: breedingCounter ?? this.breedingCounter,
+        createdAt: createdAt ?? this.createdAt,
+        updatedAt: updatedAt ?? this.updatedAt,
+      );
+  PartyPokemon copyWithCompanion(PartyPokemonsCompanion data) {
+    return PartyPokemon(
+      id: data.id.present ? data.id.value : this.id,
+      partyId: data.partyId.present ? data.partyId.value : this.partyId,
+      pokemonId: data.pokemonId.present ? data.pokemonId.value : this.pokemonId,
+      position: data.position.present ? data.position.value : this.position,
+      breedingCounter: data.breedingCounter.present
+          ? data.breedingCounter.value
+          : this.breedingCounter,
+      createdAt: data.createdAt.present ? data.createdAt.value : this.createdAt,
+      updatedAt: data.updatedAt.present ? data.updatedAt.value : this.updatedAt,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PartyPokemon(')
+          ..write('id: $id, ')
+          ..write('partyId: $partyId, ')
+          ..write('pokemonId: $pokemonId, ')
+          ..write('position: $position, ')
+          ..write('breedingCounter: $breedingCounter, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+      id, partyId, pokemonId, position, breedingCounter, createdAt, updatedAt);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is PartyPokemon &&
+          other.id == this.id &&
+          other.partyId == this.partyId &&
+          other.pokemonId == this.pokemonId &&
+          other.position == this.position &&
+          other.breedingCounter == this.breedingCounter &&
+          other.createdAt == this.createdAt &&
+          other.updatedAt == this.updatedAt);
+}
+
+class PartyPokemonsCompanion extends UpdateCompanion<PartyPokemon> {
+  final Value<int> id;
+  final Value<int> partyId;
+  final Value<int> pokemonId;
+  final Value<int> position;
+  final Value<int> breedingCounter;
+  final Value<DateTime> createdAt;
+  final Value<DateTime> updatedAt;
+  const PartyPokemonsCompanion({
+    this.id = const Value.absent(),
+    this.partyId = const Value.absent(),
+    this.pokemonId = const Value.absent(),
+    this.position = const Value.absent(),
+    this.breedingCounter = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+  });
+  PartyPokemonsCompanion.insert({
+    this.id = const Value.absent(),
+    required int partyId,
+    required int pokemonId,
+    required int position,
+    this.breedingCounter = const Value.absent(),
+    this.createdAt = const Value.absent(),
+    this.updatedAt = const Value.absent(),
+  })  : partyId = Value(partyId),
+        pokemonId = Value(pokemonId),
+        position = Value(position);
+  static Insertable<PartyPokemon> custom({
+    Expression<int>? id,
+    Expression<int>? partyId,
+    Expression<int>? pokemonId,
+    Expression<int>? position,
+    Expression<int>? breedingCounter,
+    Expression<DateTime>? createdAt,
+    Expression<DateTime>? updatedAt,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (partyId != null) 'party_id': partyId,
+      if (pokemonId != null) 'pokemon_id': pokemonId,
+      if (position != null) 'position': position,
+      if (breedingCounter != null) 'breeding_counter': breedingCounter,
+      if (createdAt != null) 'created_at': createdAt,
+      if (updatedAt != null) 'updated_at': updatedAt,
+    });
+  }
+
+  PartyPokemonsCompanion copyWith(
+      {Value<int>? id,
+      Value<int>? partyId,
+      Value<int>? pokemonId,
+      Value<int>? position,
+      Value<int>? breedingCounter,
+      Value<DateTime>? createdAt,
+      Value<DateTime>? updatedAt}) {
+    return PartyPokemonsCompanion(
+      id: id ?? this.id,
+      partyId: partyId ?? this.partyId,
+      pokemonId: pokemonId ?? this.pokemonId,
+      position: position ?? this.position,
+      breedingCounter: breedingCounter ?? this.breedingCounter,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (partyId.present) {
+      map['party_id'] = Variable<int>(partyId.value);
+    }
+    if (pokemonId.present) {
+      map['pokemon_id'] = Variable<int>(pokemonId.value);
+    }
+    if (position.present) {
+      map['position'] = Variable<int>(position.value);
+    }
+    if (breedingCounter.present) {
+      map['breeding_counter'] = Variable<int>(breedingCounter.value);
+    }
+    if (createdAt.present) {
+      map['created_at'] = Variable<DateTime>(createdAt.value);
+    }
+    if (updatedAt.present) {
+      map['updated_at'] = Variable<DateTime>(updatedAt.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PartyPokemonsCompanion(')
+          ..write('id: $id, ')
+          ..write('partyId: $partyId, ')
+          ..write('pokemonId: $pokemonId, ')
+          ..write('position: $position, ')
+          ..write('breedingCounter: $breedingCounter, ')
+          ..write('createdAt: $createdAt, ')
+          ..write('updatedAt: $updatedAt')
+          ..write(')'))
+        .toString();
+  }
+}
+
 abstract class _$LocalDatabase extends GeneratedDatabase {
   _$LocalDatabase(QueryExecutor e) : super(e);
   $LocalDatabaseManager get managers => $LocalDatabaseManager(this);
   late final $PartiesTable parties = $PartiesTable(this);
+  late final $PartyPokemonsTable partyPokemons = $PartyPokemonsTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities => [parties];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [parties, partyPokemons];
 }
 
 typedef $$PartiesTableCreateCompanionBuilder = PartiesCompanion Function({
@@ -332,6 +725,26 @@ typedef $$PartiesTableUpdateCompanionBuilder = PartiesCompanion Function({
   Value<DateTime> createdAt,
   Value<DateTime> updatedAt,
 });
+
+final class $$PartiesTableReferences
+    extends BaseReferences<_$LocalDatabase, $PartiesTable, Party> {
+  $$PartiesTableReferences(super.$_db, super.$_table, super.$_typedResult);
+
+  static MultiTypedResultKey<$PartyPokemonsTable, List<PartyPokemon>>
+      _partyPokemonsRefsTable(_$LocalDatabase db) =>
+          MultiTypedResultKey.fromTable(db.partyPokemons,
+              aliasName: $_aliasNameGenerator(
+                  db.parties.id, db.partyPokemons.partyId));
+
+  $$PartyPokemonsTableProcessedTableManager get partyPokemonsRefs {
+    final manager = $$PartyPokemonsTableTableManager($_db, $_db.partyPokemons)
+        .filter((f) => f.partyId.id.sqlEquals($_itemColumn<int>('id')!));
+
+    final cache = $_typedResult.readTableOrNull(_partyPokemonsRefsTable($_db));
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: cache));
+  }
+}
 
 class $$PartiesTableFilterComposer
     extends Composer<_$LocalDatabase, $PartiesTable> {
@@ -358,6 +771,27 @@ class $$PartiesTableFilterComposer
 
   ColumnFilters<DateTime> get updatedAt => $composableBuilder(
       column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  Expression<bool> partyPokemonsRefs(
+      Expression<bool> Function($$PartyPokemonsTableFilterComposer f) f) {
+    final $$PartyPokemonsTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $db.partyPokemons,
+        getReferencedColumn: (t) => t.partyId,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$PartyPokemonsTableFilterComposer(
+              $db: $db,
+              $table: $db.partyPokemons,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
 }
 
 class $$PartiesTableOrderingComposer
@@ -409,6 +843,27 @@ class $$PartiesTableAnnotationComposer
 
   GeneratedColumn<DateTime> get updatedAt =>
       $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  Expression<T> partyPokemonsRefs<T extends Object>(
+      Expression<T> Function($$PartyPokemonsTableAnnotationComposer a) f) {
+    final $$PartyPokemonsTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.id,
+        referencedTable: $db.partyPokemons,
+        getReferencedColumn: (t) => t.partyId,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$PartyPokemonsTableAnnotationComposer(
+              $db: $db,
+              $table: $db.partyPokemons,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return f(composer);
+  }
 }
 
 class $$PartiesTableTableManager extends RootTableManager<
@@ -420,9 +875,9 @@ class $$PartiesTableTableManager extends RootTableManager<
     $$PartiesTableAnnotationComposer,
     $$PartiesTableCreateCompanionBuilder,
     $$PartiesTableUpdateCompanionBuilder,
-    (Party, BaseReferences<_$LocalDatabase, $PartiesTable, Party>),
+    (Party, $$PartiesTableReferences),
     Party,
-    PrefetchHooks Function()> {
+    PrefetchHooks Function({bool partyPokemonsRefs})> {
   $$PartiesTableTableManager(_$LocalDatabase db, $PartiesTable table)
       : super(TableManagerState(
           db: db,
@@ -462,9 +917,35 @@ class $$PartiesTableTableManager extends RootTableManager<
             updatedAt: updatedAt,
           ),
           withReferenceMapper: (p0) => p0
-              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .map((e) =>
+                  (e.readTable(table), $$PartiesTableReferences(db, table, e)))
               .toList(),
-          prefetchHooksCallback: null,
+          prefetchHooksCallback: ({partyPokemonsRefs = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [
+                if (partyPokemonsRefs) db.partyPokemons
+              ],
+              addJoins: null,
+              getPrefetchedDataCallback: (items) async {
+                return [
+                  if (partyPokemonsRefs)
+                    await $_getPrefetchedData<Party, $PartiesTable,
+                            PartyPokemon>(
+                        currentTable: table,
+                        referencedTable: $$PartiesTableReferences
+                            ._partyPokemonsRefsTable(db),
+                        managerFromTypedResult: (p0) =>
+                            $$PartiesTableReferences(db, table, p0)
+                                .partyPokemonsRefs,
+                        referencedItemsForCurrentItem: (item,
+                                referencedItems) =>
+                            referencedItems.where((e) => e.partyId == item.id),
+                        typedResults: items)
+                ];
+              },
+            );
+          },
         ));
 }
 
@@ -477,13 +958,318 @@ typedef $$PartiesTableProcessedTableManager = ProcessedTableManager<
     $$PartiesTableAnnotationComposer,
     $$PartiesTableCreateCompanionBuilder,
     $$PartiesTableUpdateCompanionBuilder,
-    (Party, BaseReferences<_$LocalDatabase, $PartiesTable, Party>),
+    (Party, $$PartiesTableReferences),
     Party,
-    PrefetchHooks Function()>;
+    PrefetchHooks Function({bool partyPokemonsRefs})>;
+typedef $$PartyPokemonsTableCreateCompanionBuilder = PartyPokemonsCompanion
+    Function({
+  Value<int> id,
+  required int partyId,
+  required int pokemonId,
+  required int position,
+  Value<int> breedingCounter,
+  Value<DateTime> createdAt,
+  Value<DateTime> updatedAt,
+});
+typedef $$PartyPokemonsTableUpdateCompanionBuilder = PartyPokemonsCompanion
+    Function({
+  Value<int> id,
+  Value<int> partyId,
+  Value<int> pokemonId,
+  Value<int> position,
+  Value<int> breedingCounter,
+  Value<DateTime> createdAt,
+  Value<DateTime> updatedAt,
+});
+
+final class $$PartyPokemonsTableReferences
+    extends BaseReferences<_$LocalDatabase, $PartyPokemonsTable, PartyPokemon> {
+  $$PartyPokemonsTableReferences(
+      super.$_db, super.$_table, super.$_typedResult);
+
+  static $PartiesTable _partyIdTable(_$LocalDatabase db) =>
+      db.parties.createAlias(
+          $_aliasNameGenerator(db.partyPokemons.partyId, db.parties.id));
+
+  $$PartiesTableProcessedTableManager get partyId {
+    final $_column = $_itemColumn<int>('party_id')!;
+
+    final manager = $$PartiesTableTableManager($_db, $_db.parties)
+        .filter((f) => f.id.sqlEquals($_column));
+    final item = $_typedResult.readTableOrNull(_partyIdTable($_db));
+    if (item == null) return manager;
+    return ProcessedTableManager(
+        manager.$state.copyWith(prefetchedData: [item]));
+  }
+}
+
+class $$PartyPokemonsTableFilterComposer
+    extends Composer<_$LocalDatabase, $PartyPokemonsTable> {
+  $$PartyPokemonsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get pokemonId => $composableBuilder(
+      column: $table.pokemonId, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get position => $composableBuilder(
+      column: $table.position, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<int> get breedingCounter => $composableBuilder(
+      column: $table.breedingCounter,
+      builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<DateTime> get updatedAt => $composableBuilder(
+      column: $table.updatedAt, builder: (column) => ColumnFilters(column));
+
+  $$PartiesTableFilterComposer get partyId {
+    final $$PartiesTableFilterComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.partyId,
+        referencedTable: $db.parties,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$PartiesTableFilterComposer(
+              $db: $db,
+              $table: $db.parties,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$PartyPokemonsTableOrderingComposer
+    extends Composer<_$LocalDatabase, $PartyPokemonsTable> {
+  $$PartyPokemonsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+      column: $table.id, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get pokemonId => $composableBuilder(
+      column: $table.pokemonId, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get position => $composableBuilder(
+      column: $table.position, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<int> get breedingCounter => $composableBuilder(
+      column: $table.breedingCounter,
+      builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get createdAt => $composableBuilder(
+      column: $table.createdAt, builder: (column) => ColumnOrderings(column));
+
+  ColumnOrderings<DateTime> get updatedAt => $composableBuilder(
+      column: $table.updatedAt, builder: (column) => ColumnOrderings(column));
+
+  $$PartiesTableOrderingComposer get partyId {
+    final $$PartiesTableOrderingComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.partyId,
+        referencedTable: $db.parties,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$PartiesTableOrderingComposer(
+              $db: $db,
+              $table: $db.parties,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$PartyPokemonsTableAnnotationComposer
+    extends Composer<_$LocalDatabase, $PartyPokemonsTable> {
+  $$PartyPokemonsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<int> get pokemonId =>
+      $composableBuilder(column: $table.pokemonId, builder: (column) => column);
+
+  GeneratedColumn<int> get position =>
+      $composableBuilder(column: $table.position, builder: (column) => column);
+
+  GeneratedColumn<int> get breedingCounter => $composableBuilder(
+      column: $table.breedingCounter, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get createdAt =>
+      $composableBuilder(column: $table.createdAt, builder: (column) => column);
+
+  GeneratedColumn<DateTime> get updatedAt =>
+      $composableBuilder(column: $table.updatedAt, builder: (column) => column);
+
+  $$PartiesTableAnnotationComposer get partyId {
+    final $$PartiesTableAnnotationComposer composer = $composerBuilder(
+        composer: this,
+        getCurrentColumn: (t) => t.partyId,
+        referencedTable: $db.parties,
+        getReferencedColumn: (t) => t.id,
+        builder: (joinBuilder,
+                {$addJoinBuilderToRootComposer,
+                $removeJoinBuilderFromRootComposer}) =>
+            $$PartiesTableAnnotationComposer(
+              $db: $db,
+              $table: $db.parties,
+              $addJoinBuilderToRootComposer: $addJoinBuilderToRootComposer,
+              joinBuilder: joinBuilder,
+              $removeJoinBuilderFromRootComposer:
+                  $removeJoinBuilderFromRootComposer,
+            ));
+    return composer;
+  }
+}
+
+class $$PartyPokemonsTableTableManager extends RootTableManager<
+    _$LocalDatabase,
+    $PartyPokemonsTable,
+    PartyPokemon,
+    $$PartyPokemonsTableFilterComposer,
+    $$PartyPokemonsTableOrderingComposer,
+    $$PartyPokemonsTableAnnotationComposer,
+    $$PartyPokemonsTableCreateCompanionBuilder,
+    $$PartyPokemonsTableUpdateCompanionBuilder,
+    (PartyPokemon, $$PartyPokemonsTableReferences),
+    PartyPokemon,
+    PrefetchHooks Function({bool partyId})> {
+  $$PartyPokemonsTableTableManager(
+      _$LocalDatabase db, $PartyPokemonsTable table)
+      : super(TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$PartyPokemonsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$PartyPokemonsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$PartyPokemonsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            Value<int> partyId = const Value.absent(),
+            Value<int> pokemonId = const Value.absent(),
+            Value<int> position = const Value.absent(),
+            Value<int> breedingCounter = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+          }) =>
+              PartyPokemonsCompanion(
+            id: id,
+            partyId: partyId,
+            pokemonId: pokemonId,
+            position: position,
+            breedingCounter: breedingCounter,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          createCompanionCallback: ({
+            Value<int> id = const Value.absent(),
+            required int partyId,
+            required int pokemonId,
+            required int position,
+            Value<int> breedingCounter = const Value.absent(),
+            Value<DateTime> createdAt = const Value.absent(),
+            Value<DateTime> updatedAt = const Value.absent(),
+          }) =>
+              PartyPokemonsCompanion.insert(
+            id: id,
+            partyId: partyId,
+            pokemonId: pokemonId,
+            position: position,
+            breedingCounter: breedingCounter,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+          ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (
+                    e.readTable(table),
+                    $$PartyPokemonsTableReferences(db, table, e)
+                  ))
+              .toList(),
+          prefetchHooksCallback: ({partyId = false}) {
+            return PrefetchHooks(
+              db: db,
+              explicitlyWatchedTables: [],
+              addJoins: <
+                  T extends TableManagerState<
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic,
+                      dynamic>>(state) {
+                if (partyId) {
+                  state = state.withJoin(
+                    currentTable: table,
+                    currentColumn: table.partyId,
+                    referencedTable:
+                        $$PartyPokemonsTableReferences._partyIdTable(db),
+                    referencedColumn:
+                        $$PartyPokemonsTableReferences._partyIdTable(db).id,
+                  ) as T;
+                }
+
+                return state;
+              },
+              getPrefetchedDataCallback: (items) async {
+                return [];
+              },
+            );
+          },
+        ));
+}
+
+typedef $$PartyPokemonsTableProcessedTableManager = ProcessedTableManager<
+    _$LocalDatabase,
+    $PartyPokemonsTable,
+    PartyPokemon,
+    $$PartyPokemonsTableFilterComposer,
+    $$PartyPokemonsTableOrderingComposer,
+    $$PartyPokemonsTableAnnotationComposer,
+    $$PartyPokemonsTableCreateCompanionBuilder,
+    $$PartyPokemonsTableUpdateCompanionBuilder,
+    (PartyPokemon, $$PartyPokemonsTableReferences),
+    PartyPokemon,
+    PrefetchHooks Function({bool partyId})>;
 
 class $LocalDatabaseManager {
   final _$LocalDatabase _db;
   $LocalDatabaseManager(this._db);
   $$PartiesTableTableManager get parties =>
       $$PartiesTableTableManager(_db, _db.parties);
+  $$PartyPokemonsTableTableManager get partyPokemons =>
+      $$PartyPokemonsTableTableManager(_db, _db.partyPokemons);
 }

--- a/packages/domain/lib/domain.dart
+++ b/packages/domain/lib/domain.dart
@@ -9,4 +9,5 @@ export 'src/core/core.dart';
 export 'src/features/pokemon/pokemon.dart';
 export 'src/features/pokemon/pokemon_state.dart';
 export 'src/features/party/party.dart';
+export 'src/features/party/party_pokemon.dart';
 export 'src/features/party/party_state.dart';

--- a/packages/domain/lib/src/features/party/party.dart
+++ b/packages/domain/lib/src/features/party/party.dart
@@ -50,7 +50,7 @@ abstract class Party with _$Party {
 
 /// パーティの表示用スロット情報。
 @freezed
-class PartySlot with _$PartySlot {
+sealed class PartySlot with _$PartySlot {
   const PartySlot._();
 
   /// 埋まっているスロット（育成カウンター情報を含む）。
@@ -68,21 +68,21 @@ class PartySlot with _$PartySlot {
 
   /// 進化条件を満たしているかどうかを判定する。
   bool get canEvolve {
-    return when(
-      filled: (partyPokemonId, pokemonId, position, breedingCounter) => breedingCounter >= 10,
-      empty: (position) => false,
-    );
+    if (this is _PartySlotFilled) {
+      final filled = this as _PartySlotFilled;
+      return filled.breedingCounter >= 10;
+    }
+    return false;
   }
 
   /// 育成進捗を示すパーセンテージ（0-100）を計算する。
   int get progressPercentage {
-    return when(
-      filled: (partyPokemonId, pokemonId, position, breedingCounter) {
-        const maxCounter = 10;
-        final percentage = (breedingCounter / maxCounter * 100).round();
-        return percentage > 100 ? 100 : percentage;
-      },
-      empty: (position) => 0,
-    );
+    if (this is _PartySlotFilled) {
+      final filled = this as _PartySlotFilled;
+      const maxCounter = 10;
+      final percentage = (filled.breedingCounter / maxCounter * 100).round();
+      return percentage > 100 ? 100 : percentage;
+    }
+    return 0;
   }
 }

--- a/packages/domain/lib/src/features/party/party.dart
+++ b/packages/domain/lib/src/features/party/party.dart
@@ -50,7 +50,7 @@ abstract class Party with _$Party {
 
 /// パーティの表示用スロット情報。
 @freezed
-sealed class PartySlot with _$PartySlot {
+class PartySlot with _$PartySlot {
   const PartySlot._();
 
   /// 埋まっているスロット（育成カウンター情報を含む）。
@@ -69,20 +69,20 @@ sealed class PartySlot with _$PartySlot {
   /// 進化条件を満たしているかどうかを判定する。
   bool get canEvolve {
     return when(
-      filled: (_, __, ___, breedingCounter) => breedingCounter >= 10,
-      empty: (_) => false,
+      filled: (partyPokemonId, pokemonId, position, breedingCounter) => breedingCounter >= 10,
+      empty: (position) => false,
     );
   }
 
   /// 育成進捗を示すパーセンテージ（0-100）を計算する。
   int get progressPercentage {
     return when(
-      filled: (_, __, ___, breedingCounter) {
+      filled: (partyPokemonId, pokemonId, position, breedingCounter) {
         const maxCounter = 10;
         final percentage = (breedingCounter / maxCounter * 100).round();
         return percentage > 100 ? 100 : percentage;
       },
-      empty: (_) => 0,
+      empty: (position) => 0,
     );
   }
 }

--- a/packages/domain/lib/src/features/party/party.dart
+++ b/packages/domain/lib/src/features/party/party.dart
@@ -53,14 +53,36 @@ abstract class Party with _$Party {
 sealed class PartySlot with _$PartySlot {
   const PartySlot._();
 
-  /// 埋まっているスロット。
+  /// 埋まっているスロット（育成カウンター情報を含む）。
   const factory PartySlot.filled({
+    required int partyPokemonId,
     required int pokemonId,
     required int position,
+    required int breedingCounter,
   }) = _PartySlotFilled;
 
   /// 空いているスロット。
   const factory PartySlot.empty({
     required int position,
   }) = _PartySlotEmpty;
+
+  /// 進化条件を満たしているかどうかを判定する。
+  bool get canEvolve {
+    return when(
+      filled: (_, __, ___, breedingCounter) => breedingCounter >= 10,
+      empty: (_) => false,
+    );
+  }
+
+  /// 育成進捗を示すパーセンテージ（0-100）を計算する。
+  int get progressPercentage {
+    return when(
+      filled: (_, __, ___, breedingCounter) {
+        const maxCounter = 10;
+        final percentage = (breedingCounter / maxCounter * 100).round();
+        return percentage > 100 ? 100 : percentage;
+      },
+      empty: (_) => 0,
+    );
+  }
 }

--- a/packages/domain/lib/src/features/party/party.freezed.dart
+++ b/packages/domain/lib/src/features/party/party.freezed.dart
@@ -291,12 +291,18 @@ class _$PartySlotCopyWithImpl<$Res> implements $PartySlotCopyWith<$Res> {
 /// @nodoc
 
 class _PartySlotFilled extends PartySlot {
-  const _PartySlotFilled({required this.pokemonId, required this.position})
+  const _PartySlotFilled(
+      {required this.partyPokemonId,
+      required this.pokemonId,
+      required this.position,
+      required this.breedingCounter})
       : super._();
 
+  final int partyPokemonId;
   final int pokemonId;
   @override
   final int position;
+  final int breedingCounter;
 
   /// Create a copy of PartySlot
   /// with the given fields replaced by the non-null parameter values.
@@ -311,18 +317,23 @@ class _PartySlotFilled extends PartySlot {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _PartySlotFilled &&
+            (identical(other.partyPokemonId, partyPokemonId) ||
+                other.partyPokemonId == partyPokemonId) &&
             (identical(other.pokemonId, pokemonId) ||
                 other.pokemonId == pokemonId) &&
             (identical(other.position, position) ||
-                other.position == position));
+                other.position == position) &&
+            (identical(other.breedingCounter, breedingCounter) ||
+                other.breedingCounter == breedingCounter));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, pokemonId, position);
+  int get hashCode => Object.hash(
+      runtimeType, partyPokemonId, pokemonId, position, breedingCounter);
 
   @override
   String toString() {
-    return 'PartySlot.filled(pokemonId: $pokemonId, position: $position)';
+    return 'PartySlot.filled(partyPokemonId: $partyPokemonId, pokemonId: $pokemonId, position: $position, breedingCounter: $breedingCounter)';
   }
 }
 
@@ -334,7 +345,8 @@ abstract mixin class _$PartySlotFilledCopyWith<$Res>
       __$PartySlotFilledCopyWithImpl;
   @override
   @useResult
-  $Res call({int pokemonId, int position});
+  $Res call(
+      {int partyPokemonId, int pokemonId, int position, int breedingCounter});
 }
 
 /// @nodoc
@@ -350,10 +362,16 @@ class __$PartySlotFilledCopyWithImpl<$Res>
   @override
   @pragma('vm:prefer-inline')
   $Res call({
+    Object? partyPokemonId = null,
     Object? pokemonId = null,
     Object? position = null,
+    Object? breedingCounter = null,
   }) {
     return _then(_PartySlotFilled(
+      partyPokemonId: null == partyPokemonId
+          ? _self.partyPokemonId
+          : partyPokemonId // ignore: cast_nullable_to_non_nullable
+              as int,
       pokemonId: null == pokemonId
           ? _self.pokemonId
           : pokemonId // ignore: cast_nullable_to_non_nullable
@@ -361,6 +379,10 @@ class __$PartySlotFilledCopyWithImpl<$Res>
       position: null == position
           ? _self.position
           : position // ignore: cast_nullable_to_non_nullable
+              as int,
+      breedingCounter: null == breedingCounter
+          ? _self.breedingCounter
+          : breedingCounter // ignore: cast_nullable_to_non_nullable
               as int,
     ));
   }

--- a/packages/domain/lib/src/features/party/party_pokemon.dart
+++ b/packages/domain/lib/src/features/party/party_pokemon.dart
@@ -1,0 +1,64 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'party_pokemon.freezed.dart';
+
+/// パーティ内のポケモンを表すエンティティ（育成カウンター情報を含む）。
+@freezed
+abstract class PartyPokemon with _$PartyPokemon {
+  const PartyPokemon._();
+
+  /// パーティ内ポケモンエンティティを作成する。
+  const factory PartyPokemon({
+    required int id,
+    required int partyId,
+    required int pokemonId,
+    required int position,
+    required int breedingCounter,
+    required DateTime createdAt,
+    required DateTime updatedAt,
+  }) = _PartyPokemon;
+
+  /// 育成カウンターを増加させる。
+  PartyPokemon incrementCounter() {
+    return copyWith(
+      breedingCounter: breedingCounter + 1,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// 育成カウンターを減少させる（0未満にはならない）。
+  PartyPokemon decrementCounter() {
+    return copyWith(
+      breedingCounter: breedingCounter > 0 ? breedingCounter - 1 : 0,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// 育成カウンターをリセットする。
+  PartyPokemon resetCounter() {
+    return copyWith(
+      breedingCounter: 0,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// 育成カウンターを指定値に設定する。
+  PartyPokemon setCounter(int value) {
+    return copyWith(
+      breedingCounter: value < 0 ? 0 : value,
+      updatedAt: DateTime.now(),
+    );
+  }
+
+  /// 進化条件を満たしているかどうかを判定する。
+  /// 現在は仮実装として、カウンターが10以上の場合に進化可能とする。
+  bool get canEvolve => breedingCounter >= 10;
+
+  /// 育成進捗を示すパーセンテージ（0-100）を計算する。
+  /// 進化条件（カウンター10）を100%として計算。
+  int get progressPercentage {
+    const maxCounter = 10;
+    final percentage = (breedingCounter / maxCounter * 100).round();
+    return percentage > 100 ? 100 : percentage;
+  }
+}

--- a/packages/domain/lib/src/features/party/party_pokemon.freezed.dart
+++ b/packages/domain/lib/src/features/party/party_pokemon.freezed.dart
@@ -1,0 +1,269 @@
+// dart format width=80
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'party_pokemon.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$PartyPokemon {
+  int get id;
+  int get partyId;
+  int get pokemonId;
+  int get position;
+  int get breedingCounter;
+  DateTime get createdAt;
+  DateTime get updatedAt;
+
+  /// Create a copy of PartyPokemon
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  $PartyPokemonCopyWith<PartyPokemon> get copyWith =>
+      _$PartyPokemonCopyWithImpl<PartyPokemon>(
+          this as PartyPokemon, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is PartyPokemon &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.partyId, partyId) || other.partyId == partyId) &&
+            (identical(other.pokemonId, pokemonId) ||
+                other.pokemonId == pokemonId) &&
+            (identical(other.position, position) ||
+                other.position == position) &&
+            (identical(other.breedingCounter, breedingCounter) ||
+                other.breedingCounter == breedingCounter) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, partyId, pokemonId, position,
+      breedingCounter, createdAt, updatedAt);
+
+  @override
+  String toString() {
+    return 'PartyPokemon(id: $id, partyId: $partyId, pokemonId: $pokemonId, position: $position, breedingCounter: $breedingCounter, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class $PartyPokemonCopyWith<$Res> {
+  factory $PartyPokemonCopyWith(
+          PartyPokemon value, $Res Function(PartyPokemon) _then) =
+      _$PartyPokemonCopyWithImpl;
+  @useResult
+  $Res call(
+      {int id,
+      int partyId,
+      int pokemonId,
+      int position,
+      int breedingCounter,
+      DateTime createdAt,
+      DateTime updatedAt});
+}
+
+/// @nodoc
+class _$PartyPokemonCopyWithImpl<$Res> implements $PartyPokemonCopyWith<$Res> {
+  _$PartyPokemonCopyWithImpl(this._self, this._then);
+
+  final PartyPokemon _self;
+  final $Res Function(PartyPokemon) _then;
+
+  /// Create a copy of PartyPokemon
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? partyId = null,
+    Object? pokemonId = null,
+    Object? position = null,
+    Object? breedingCounter = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_self.copyWith(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      partyId: null == partyId
+          ? _self.partyId
+          : partyId // ignore: cast_nullable_to_non_nullable
+              as int,
+      pokemonId: null == pokemonId
+          ? _self.pokemonId
+          : pokemonId // ignore: cast_nullable_to_non_nullable
+              as int,
+      position: null == position
+          ? _self.position
+          : position // ignore: cast_nullable_to_non_nullable
+              as int,
+      breedingCounter: null == breedingCounter
+          ? _self.breedingCounter
+          : breedingCounter // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+/// @nodoc
+
+class _PartyPokemon extends PartyPokemon {
+  const _PartyPokemon(
+      {required this.id,
+      required this.partyId,
+      required this.pokemonId,
+      required this.position,
+      required this.breedingCounter,
+      required this.createdAt,
+      required this.updatedAt})
+      : super._();
+
+  @override
+  final int id;
+  @override
+  final int partyId;
+  @override
+  final int pokemonId;
+  @override
+  final int position;
+  @override
+  final int breedingCounter;
+  @override
+  final DateTime createdAt;
+  @override
+  final DateTime updatedAt;
+
+  /// Create a copy of PartyPokemon
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @pragma('vm:prefer-inline')
+  _$PartyPokemonCopyWith<_PartyPokemon> get copyWith =>
+      __$PartyPokemonCopyWithImpl<_PartyPokemon>(this, _$identity);
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _PartyPokemon &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.partyId, partyId) || other.partyId == partyId) &&
+            (identical(other.pokemonId, pokemonId) ||
+                other.pokemonId == pokemonId) &&
+            (identical(other.position, position) ||
+                other.position == position) &&
+            (identical(other.breedingCounter, breedingCounter) ||
+                other.breedingCounter == breedingCounter) &&
+            (identical(other.createdAt, createdAt) ||
+                other.createdAt == createdAt) &&
+            (identical(other.updatedAt, updatedAt) ||
+                other.updatedAt == updatedAt));
+  }
+
+  @override
+  int get hashCode => Object.hash(runtimeType, id, partyId, pokemonId, position,
+      breedingCounter, createdAt, updatedAt);
+
+  @override
+  String toString() {
+    return 'PartyPokemon(id: $id, partyId: $partyId, pokemonId: $pokemonId, position: $position, breedingCounter: $breedingCounter, createdAt: $createdAt, updatedAt: $updatedAt)';
+  }
+}
+
+/// @nodoc
+abstract mixin class _$PartyPokemonCopyWith<$Res>
+    implements $PartyPokemonCopyWith<$Res> {
+  factory _$PartyPokemonCopyWith(
+          _PartyPokemon value, $Res Function(_PartyPokemon) _then) =
+      __$PartyPokemonCopyWithImpl;
+  @override
+  @useResult
+  $Res call(
+      {int id,
+      int partyId,
+      int pokemonId,
+      int position,
+      int breedingCounter,
+      DateTime createdAt,
+      DateTime updatedAt});
+}
+
+/// @nodoc
+class __$PartyPokemonCopyWithImpl<$Res>
+    implements _$PartyPokemonCopyWith<$Res> {
+  __$PartyPokemonCopyWithImpl(this._self, this._then);
+
+  final _PartyPokemon _self;
+  final $Res Function(_PartyPokemon) _then;
+
+  /// Create a copy of PartyPokemon
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $Res call({
+    Object? id = null,
+    Object? partyId = null,
+    Object? pokemonId = null,
+    Object? position = null,
+    Object? breedingCounter = null,
+    Object? createdAt = null,
+    Object? updatedAt = null,
+  }) {
+    return _then(_PartyPokemon(
+      id: null == id
+          ? _self.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as int,
+      partyId: null == partyId
+          ? _self.partyId
+          : partyId // ignore: cast_nullable_to_non_nullable
+              as int,
+      pokemonId: null == pokemonId
+          ? _self.pokemonId
+          : pokemonId // ignore: cast_nullable_to_non_nullable
+              as int,
+      position: null == position
+          ? _self.position
+          : position // ignore: cast_nullable_to_non_nullable
+              as int,
+      breedingCounter: null == breedingCounter
+          ? _self.breedingCounter
+          : breedingCounter // ignore: cast_nullable_to_non_nullable
+              as int,
+      createdAt: null == createdAt
+          ? _self.createdAt
+          : createdAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      updatedAt: null == updatedAt
+          ? _self.updatedAt
+          : updatedAt // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+    ));
+  }
+}
+
+// dart format on

--- a/packages/domain/lib/src/features/party/party_state.dart
+++ b/packages/domain/lib/src/features/party/party_state.dart
@@ -1,8 +1,10 @@
+import 'package:data/src/services/local_storage/local_database_provider.dart';
 import 'package:data/src/services/party/party_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'party.dart';
+import 'party_pokemon.dart';
 
 part 'party_state.g.dart';
 
@@ -133,29 +135,100 @@ class CurrentPartyState extends _$CurrentPartyState {
     }
   }
 
-  /// パーティの6スロット情報を取得する。
-  List<PartySlot> getPartySlots() {
+  /// パーティの6スロット情報を取得する（育成カウンター情報を含む）。
+  Future<List<PartySlot>> getPartySlots() async {
     final currentParty = state.valueOrNull;
     if (currentParty == null) {
       return List.generate(6, (index) => PartySlot.empty(position: index));
     }
 
-    final slots = <PartySlot>[];
-    
-    // 埋まっているスロット
-    for (int i = 0; i < currentParty.pokemonIds.length; i++) {
-      slots.add(PartySlot.filled(
-        pokemonId: currentParty.pokemonIds[i],
-        position: i,
-      ));
+    try {
+      final database = ref.read(localDatabaseProvider);
+      final partyPokemons = await database.getPartyPokemons(currentParty.id);
+      
+      final slots = <PartySlot>[];
+      
+      // パーティポケモンをposition順にソート
+      partyPokemons.sort((a, b) => a.position.compareTo(b.position));
+      
+      // 埋まっているスロット
+      for (final partyPokemon in partyPokemons) {
+        slots.add(PartySlot.filled(
+          partyPokemonId: partyPokemon.id,
+          pokemonId: partyPokemon.pokemonId,
+          position: partyPokemon.position,
+          breedingCounter: partyPokemon.breedingCounter,
+        ));
+      }
+      
+      // 空のスロット
+      for (int i = partyPokemons.length; i < 6; i++) {
+        slots.add(PartySlot.empty(position: i));
+      }
+      
+      return slots;
+    } catch (error) {
+      debugPrint('Failed to get party slots: $error');
+      return List.generate(6, (index) => PartySlot.empty(position: index));
     }
-    
-    // 空のスロット
-    for (int i = currentParty.pokemonIds.length; i < 6; i++) {
-      slots.add(PartySlot.empty(position: i));
+  }
+
+  /// 育成カウンターを増加させる。
+  Future<void> incrementBreedingCounter(int partyPokemonId) async {
+    try {
+      final database = ref.read(localDatabaseProvider);
+      final partyPokemon = (await database.select(database.partyPokemons)
+            ..where((tbl) => tbl.id.equals(partyPokemonId)))
+          .getSingleOrNull();
+      
+      if (partyPokemon != null) {
+        await database.updateBreedingCounter(
+          partyPokemonId,
+          partyPokemon.breedingCounter + 1,
+        );
+      }
+    } catch (error, stackTrace) {
+      debugPrint('Failed to increment breeding counter: $error');
     }
-    
-    return slots;
+  }
+
+  /// 育成カウンターを減少させる。
+  Future<void> decrementBreedingCounter(int partyPokemonId) async {
+    try {
+      final database = ref.read(localDatabaseProvider);
+      final partyPokemon = (await database.select(database.partyPokemons)
+            ..where((tbl) => tbl.id.equals(partyPokemonId)))
+          .getSingleOrNull();
+      
+      if (partyPokemon != null && partyPokemon.breedingCounter > 0) {
+        await database.updateBreedingCounter(
+          partyPokemonId,
+          partyPokemon.breedingCounter - 1,
+        );
+      }
+    } catch (error, stackTrace) {
+      debugPrint('Failed to decrement breeding counter: $error');
+    }
+  }
+
+  /// 育成カウンターをリセットする。
+  Future<void> resetBreedingCounter(int partyPokemonId) async {
+    try {
+      final database = ref.read(localDatabaseProvider);
+      await database.updateBreedingCounter(partyPokemonId, 0);
+    } catch (error, stackTrace) {
+      debugPrint('Failed to reset breeding counter: $error');
+    }
+  }
+
+  /// 育成カウンターを指定値に設定する。
+  Future<void> setBreedingCounter(int partyPokemonId, int value) async {
+    try {
+      final database = ref.read(localDatabaseProvider);
+      await database.updateBreedingCounter(partyPokemonId, value < 0 ? 0 : value);
+    } catch (error, stackTrace) {
+      debugPrint('Failed to set breeding counter: $error');
+    }
   }
 
   /// 現在のパーティを再読み込みする。

--- a/packages/domain/lib/src/features/party/party_state.dart
+++ b/packages/domain/lib/src/features/party/party_state.dart
@@ -4,7 +4,6 @@ import 'package:flutter/foundation.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
 import 'party.dart';
-import 'party_pokemon.dart';
 
 part 'party_state.g.dart';
 
@@ -177,7 +176,7 @@ class CurrentPartyState extends _$CurrentPartyState {
   Future<void> incrementBreedingCounter(int partyPokemonId) async {
     try {
       final database = ref.read(localDatabaseProvider);
-      final partyPokemon = (await database.select(database.partyPokemons)
+      final partyPokemon = await (database.select(database.partyPokemons)
             ..where((tbl) => tbl.id.equals(partyPokemonId)))
           .getSingleOrNull();
       
@@ -187,7 +186,7 @@ class CurrentPartyState extends _$CurrentPartyState {
           partyPokemon.breedingCounter + 1,
         );
       }
-    } catch (error, stackTrace) {
+    } catch (error, _) {
       debugPrint('Failed to increment breeding counter: $error');
     }
   }
@@ -196,7 +195,7 @@ class CurrentPartyState extends _$CurrentPartyState {
   Future<void> decrementBreedingCounter(int partyPokemonId) async {
     try {
       final database = ref.read(localDatabaseProvider);
-      final partyPokemon = (await database.select(database.partyPokemons)
+      final partyPokemon = await (database.select(database.partyPokemons)
             ..where((tbl) => tbl.id.equals(partyPokemonId)))
           .getSingleOrNull();
       
@@ -206,7 +205,7 @@ class CurrentPartyState extends _$CurrentPartyState {
           partyPokemon.breedingCounter - 1,
         );
       }
-    } catch (error, stackTrace) {
+    } catch (error, _) {
       debugPrint('Failed to decrement breeding counter: $error');
     }
   }
@@ -216,7 +215,7 @@ class CurrentPartyState extends _$CurrentPartyState {
     try {
       final database = ref.read(localDatabaseProvider);
       await database.updateBreedingCounter(partyPokemonId, 0);
-    } catch (error, stackTrace) {
+    } catch (error, _) {
       debugPrint('Failed to reset breeding counter: $error');
     }
   }
@@ -226,7 +225,7 @@ class CurrentPartyState extends _$CurrentPartyState {
     try {
       final database = ref.read(localDatabaseProvider);
       await database.updateBreedingCounter(partyPokemonId, value < 0 ? 0 : value);
-    } catch (error, stackTrace) {
+    } catch (error, _) {
       debugPrint('Failed to set breeding counter: $error');
     }
   }

--- a/packages/domain/lib/src/features/party/party_state.g.dart
+++ b/packages/domain/lib/src/features/party/party_state.g.dart
@@ -24,7 +24,7 @@ final partyListStateProvider = AutoDisposeNotifierProvider<PartyListState,
 );
 
 typedef _$PartyListState = AutoDisposeNotifier<AsyncValue<List<Party>>>;
-String _$currentPartyStateHash() => r'628be668b882aa912b59a6e4ce190a3f6c974a15';
+String _$currentPartyStateHash() => r'1c0c1853b638d4e87ffdf810d34c51287b314955';
 
 /// 現在選択中のパーティの状態を管理するクラス。
 ///

--- a/packages/domain/lib/src/features/party/party_state.g.dart
+++ b/packages/domain/lib/src/features/party/party_state.g.dart
@@ -24,7 +24,7 @@ final partyListStateProvider = AutoDisposeNotifierProvider<PartyListState,
 );
 
 typedef _$PartyListState = AutoDisposeNotifier<AsyncValue<List<Party>>>;
-String _$currentPartyStateHash() => r'e52119cf2dc380de2b3422335c23793fda9eea10';
+String _$currentPartyStateHash() => r'628be668b882aa912b59a6e4ce190a3f6c974a15';
 
 /// 現在選択中のパーティの状態を管理するクラス。
 ///


### PR DESCRIPTION
## Summary
Issue #10で要求された育成カウンター機能を完全に実装しました。

### 🎯 実装した機能
- **育成カウンター表示**: 数値とプログレスバーによる視覚的フィードバック
- **直感的操作**: +/-ボタンによるカウンター増減
- **進化条件判定**: カウンター10以上で進化可能状態を表示
- **視覚的フィードバック**: 進化可能時の特別なUI表示（青枠、星アイコン）
- **データ永続化**: SQLiteデータベースへの自動保存

### 🏗️ アーキテクチャ変更
- **データベーススキーマ拡張**: v1 → v2マイグレーション
- **新テーブル追加**: PartyPokemonsテーブルで個別管理
- **ドメインエンティティ追加**: PartyPokemonエンティティ
- **既存データ移行**: 自動マイグレーション機能

### 📱 UI/UX改善
- **レスポンシブデザイン**: カウンター表示に適したカード比率調整
- **プログレス表示**: LinearProgressIndicatorによる進捗可視化
- **状態別スタイル**: 進化可能時のプライマリカラー強調
- **操作フィードバック**: ボタン押下時の視覚的応答

## Changes Made

### Database Layer
- `packages/data/lib/src/services/local_storage/database.dart`
  - PartyPokemonsテーブル追加
  - マイグレーション機能実装
  - 育成カウンター操作メソッド追加

### Domain Layer
- `packages/domain/lib/src/features/party/party_pokemon.dart` ✨ 新規作成
  - PartyPokemonエンティティ実装
  - 育成カウンター操作メソッド
- `packages/domain/lib/src/features/party/party.dart`
  - PartySlot拡張（育成カウンター情報追加）
  - 進化条件判定ロジック
- `packages/domain/lib/src/features/party/party_state.dart`
  - カウンター操作メソッド実装
  - データベース同期処理

### Presentation Layer
- `packages/app/lib/pages/party_page.dart`
  - 育成カウンターUI実装
  - +/-ボタン操作
  - プログレスバー表示
  - 進化可能時の特別表示

## Test plan
- [x] データベースマイグレーション動作確認
- [x] 育成カウンター増減操作テスト
- [x] 進化条件表示切り替えテスト
- [x] データ永続化確認
- [x] 静的解析パス確認
- [x] アプリケーションテスト実行

## Database Migration
⚠️ **重要**: このPRにはデータベーススキーマ変更（v1 → v2）が含まれています。
- 既存データは自動的にPartyPokemonsテーブルに移行されます
- 育成カウンターは初期値0で設定されます

## Related Issue
Closes #10

🤖 Generated with [Claude Code](https://claude.ai/code)