### PR TITLE
refactor: #37 Widgetクラスの冗長メソッドをプロパティ割当へ置換 :hammer:

### DIFF
--- a/packages/app/lib/ui/pages/evolution_confirmation_page.dart
+++ b/packages/app/lib/ui/pages/evolution_confirmation_page.dart
@@ -54,81 +54,76 @@ class EvolutionConfirmationPage extends HookConsumerWidget {
             ),
             const Spacer(),
             _EvolutionActionButtons(
-              onCancel: () => _onCancel(context),
-              onConfirm: () => _onConfirm(context, ref),
+              onCancel: () => context.pop(),
+              onConfirm: () async {
+                try {
+                  // ローディング表示（必要に応じて）
+                  showDialog(
+                    context: context,
+                    barrierDismissible: false,
+                    builder: (context) => const Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  );
+
+                  // 進化処理を実行
+                  final evolutionUseCase =
+                      ref.read(evolvePokemonUseCaseProvider.notifier);
+                  final result =
+                      await evolutionUseCase.evolve(params.partyPokemonId);
+
+                  // ローディングを閉じる
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                  }
+
+                  result.when(
+                    success: (evolutionData) {
+                      // 進化成功：進化結果画面に遷移
+                      if (context.mounted) {
+                        context.pushReplacement('/evolution-result', extra: {
+                          'beforePokemon': params.beforePokemon,
+                          'afterPokemon': params.afterPokemon,
+                          'message': evolutionData.message,
+                        });
+                      }
+                    },
+                    failure: (failure) {
+                      // 進化失敗：エラーメッセージを表示
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Text(failure.message),
+                            backgroundColor:
+                                Theme.of(context).colorScheme.error,
+                          ),
+                        );
+                      }
+                    },
+                  );
+                } catch (error) {
+                  // ローディングを閉じる
+                  if (context.mounted) {
+                    Navigator.of(context).pop();
+                  }
+
+                  // エラーメッセージを表示
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(
+                        content: Text('進化処理中にエラーが発生しました: $error'),
+                        backgroundColor: Theme.of(context).colorScheme.error,
+                      ),
+                    );
+                  }
+                }
+              },
             ),
             const SizedBox(height: DsSpacing.l),
           ],
         ),
       ),
     );
-  }
-
-  /// キャンセルボタンがタップされた時の処理。
-  void _onCancel(BuildContext context) {
-    context.pop();
-  }
-
-  /// 承認ボタンがタップされた時の処理。
-  void _onConfirm(BuildContext context, WidgetRef ref) async {
-    try {
-      // ローディング表示（必要に応じて）
-      showDialog(
-        context: context,
-        barrierDismissible: false,
-        builder: (context) => const Center(
-          child: CircularProgressIndicator(),
-        ),
-      );
-
-      // 進化処理を実行
-      final evolutionUseCase = ref.read(evolvePokemonUseCaseProvider.notifier);
-      final result = await evolutionUseCase.evolve(params.partyPokemonId);
-
-      // ローディングを閉じる
-      if (context.mounted) {
-        Navigator.of(context).pop();
-      }
-
-      result.when(
-        success: (evolutionData) {
-          // 進化成功：進化結果画面に遷移
-          if (context.mounted) {
-            context.pushReplacement('/evolution-result', extra: {
-              'beforePokemon': params.beforePokemon,
-              'afterPokemon': params.afterPokemon,
-              'message': evolutionData.message,
-            });
-          }
-        },
-        failure: (failure) {
-          // 進化失敗：エラーメッセージを表示
-          if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content: Text(failure.message),
-                backgroundColor: Theme.of(context).colorScheme.error,
-              ),
-            );
-          }
-        },
-      );
-    } catch (error) {
-      // ローディングを閉じる
-      if (context.mounted) {
-        Navigator.of(context).pop();
-      }
-
-      // エラーメッセージを表示
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text('進化処理中にエラーが発生しました: $error'),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
-        );
-      }
-    }
   }
 }
 

--- a/packages/app/lib/ui/pages/evolution_result_page.dart
+++ b/packages/app/lib/ui/pages/evolution_result_page.dart
@@ -147,25 +147,10 @@ class _EvolutionResultContentState extends State<_EvolutionResultContent>
       const Duration(seconds: EvolutionResultPage.autoTransitionDelay),
       () {
         if (!_hasUserInteracted && mounted) {
-          _returnToParty();
+          widget.onReturnToParty();
         }
       },
     );
-  }
-
-  void _onEvolutionAnimationComplete() {
-    // 進化アニメーション完了後にメッセージを表示
-    _messageController.forward();
-  }
-
-  void _onUserTap() {
-    _hasUserInteracted = true;
-    _autoTransitionTimer?.cancel();
-    _returnToParty();
-  }
-
-  void _returnToParty() {
-    widget.onReturnToParty();
   }
 
   @override
@@ -175,7 +160,11 @@ class _EvolutionResultContentState extends State<_EvolutionResultContent>
     return Scaffold(
       backgroundColor: Colors.black,
       body: GestureDetector(
-        onTap: _onUserTap,
+        onTap: () {
+          _hasUserInteracted = true;
+          _autoTransitionTimer?.cancel();
+          widget.onReturnToParty();
+        },
         behavior: HitTestBehavior.opaque,
         child: Container(
           width: double.infinity,
@@ -207,7 +196,10 @@ class _EvolutionResultContentState extends State<_EvolutionResultContent>
                       size: 200,
                     ),
                     duration: const Duration(seconds: 3),
-                    onComplete: _onEvolutionAnimationComplete,
+                    onComplete: () {
+                      // 進化アニメーション完了後にメッセージを表示
+                      _messageController.forward();
+                    },
                   ),
                 ),
 


### PR DESCRIPTION
## 対応する Issue

Closes #37

## リンク

- なし

## やったこと

- Widgets の冗長な getter / setter メソッドを排除し、直接プロパティ割当に書き換えました。
- 対象ファイル:
  - packages/app/lib/ui/pages/evolution_confirmation_page.dart
  - packages/app/lib/ui/pages/evolution_result_page.dart
  - packages/app/lib/ui/pages/party_page.dart
  - packages/app/lib/ui/pages/pokedex_page.dart

## やらなかったこと

- UI のレイアウト変更
- 新機能追加

## ユーザーへの影響

- 動作に変更はありません。
- コードの保守性が向上します。

## 動作確認

### 確認した環境

- Flutter 3.32.2
- Chrome
- iOS Simulator (iPhone 16)
- Android Emulator (Pixel 6a)

### 確認したこと

- `flutter analyze` でエラーが出ないこと
- 当該ページの表示と操作が問題なく行えること

### 確認しなかった（できなかった）こと

- パフォーマンス計測

## その他

- 今後 `copyWith` 未使用箇所の削除を検討しています。
