### PR TITLE
feat: design_systemパッケージからドメイン依存コンポーネントを除去

### DIFF
--- a/packages/app/lib/ui/features/evolution/components/evolution_effects.dart
+++ b/packages/app/lib/ui/features/evolution/components/evolution_effects.dart
@@ -439,3 +439,65 @@ class RadialBurstPainter extends CustomPainter {
         oldDelegate.color != color;
   }
 }
+
+/// 進化に使用するポケモン画像コンポーネント。
+class DsEvolutionPokemonImage extends StatelessWidget {
+  /// 進化用ポケモン画像を作成します。
+  const DsEvolutionPokemonImage({
+    required this.imageUrl,
+    required this.name,
+    super.key,
+    this.size = 150,
+  });
+
+  /// ポケモンの画像URL
+  final String imageUrl;
+
+  /// ポケモンの名前
+  final String name;
+
+  /// 画像のサイズ
+  final double size;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: Theme.of(context).colorScheme.primary,
+              width: 2,
+            ),
+          ),
+          child: ClipOval(
+            child: Image.network(
+              imageUrl,
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) {
+                return Container(
+                  color: Theme.of(context).colorScheme.surfaceContainer,
+                  child: Icon(
+                    Icons.catching_pokemon,
+                    size: size * 0.5,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          name,
+          style: Theme.of(context).textTheme.titleMedium,
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}

--- a/packages/app/lib/ui/features/evolution/components/evolution_result_content.dart
+++ b/packages/app/lib/ui/features/evolution/components/evolution_result_content.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
-import 'package:design_system/design_system.dart';
 import 'package:domain/domain.dart';
 import 'package:flutter/material.dart';
+
+import 'evolution_effects.dart';
+import 'evolution_sequence.dart';
 
 /// 進化結果コンテンツの設定
 class EvolutionResultContentConfig {

--- a/packages/app/lib/ui/features/evolution/components/evolution_sequence.dart
+++ b/packages/app/lib/ui/features/evolution/components/evolution_sequence.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'ds_evolution_effects.dart';
+import 'evolution_effects.dart';
 
 /// アニメーション段階とタイミングを管理するクラス
 class _EvolutionTimeline {
@@ -320,9 +320,9 @@ class _DsEvolutionSequenceState extends State<DsEvolutionSequence>
 /// 進化アニメーション用のポケモン画像ウィジェット。
 ///
 /// 一貫したサイズとスタイルでポケモン画像を表示します。
-class DsEvolutionPokemonImage extends StatelessWidget {
+class EvolutionPokemonImage extends StatelessWidget {
   /// 進化アニメーション用のポケモン画像を作成します。
-  const DsEvolutionPokemonImage({
+  const EvolutionPokemonImage({
     required this.imageUrl,
     required this.name,
     super.key,

--- a/packages/app/lib/ui/pages/pokedex_page.dart
+++ b/packages/app/lib/ui/pages/pokedex_page.dart
@@ -121,7 +121,10 @@ class PokedexPage extends HookConsumerWidget {
               data: (pokemons) {
                 // 検索結果が空の場合の処理
                 if (searchQuery.isNotEmpty && filteredPokemons.isEmpty) {
-                  return DsSearchEmptyState(query: searchQuery);
+                  return DsSearchEmptyState(
+                    query: searchQuery,
+                    emptyMessage: '"$searchQuery" に一致するポケモンが見つかりませんでした',
+                  );
                 }
 
                 return PokemonListView(
@@ -165,7 +168,7 @@ class _PokemonListShimmer extends StatelessWidget {
       padding: DsPadding.allS,
       itemCount: 10, // 初期表示用のShimmerアイテム数
       itemBuilder: (context, index) {
-        return const DsPokemonListShimmer();
+        return const DsListItemShimmer();
       },
     );
   }

--- a/packages/design_system/lib/design_system.dart
+++ b/packages/design_system/lib/design_system.dart
@@ -4,8 +4,6 @@ export 'src/components/ds_boxes.dart';
 export 'src/components/ds_button.dart';
 export 'src/components/ds_choice_chip.dart';
 export 'src/components/ds_divider.dart';
-export 'src/components/ds_evolution_effects.dart';
-export 'src/components/ds_evolution_sequence.dart';
 export 'src/components/ds_icon.dart';
 export 'src/components/ds_scaffold.dart';
 export 'src/components/ds_search_bar.dart';

--- a/packages/design_system/lib/src/components/ds_search_bar.dart
+++ b/packages/design_system/lib/src/components/ds_search_bar.dart
@@ -156,6 +156,8 @@ class DsSearchEmptyState extends StatelessWidget {
     super.key,
     this.query = '',
     this.onClear,
+    this.emptyMessage,
+    this.suggestionMessage,
   });
 
   /// 検索クエリ
@@ -163,6 +165,12 @@ class DsSearchEmptyState extends StatelessWidget {
 
   /// クリア操作のコールバック
   final VoidCallback? onClear;
+
+  /// 検索結果が見つからない場合のメッセージ
+  final String? emptyMessage;
+
+  /// 検索提案メッセージ
+  final String? suggestionMessage;
 
   @override
   Widget build(BuildContext context) {
@@ -179,7 +187,7 @@ class DsSearchEmptyState extends StatelessWidget {
             ),
             const SizedBox(height: DsSpacing.m),
             Text(
-              '"$query" に一致するポケモンが見つかりませんでした',
+              emptyMessage ?? '"$query" に一致する項目が見つかりませんでした',
               style: DsTypography.titleMedium.copyWith(
                 color: Theme.of(context).colorScheme.onSurface,
               ),
@@ -187,7 +195,7 @@ class DsSearchEmptyState extends StatelessWidget {
             ),
             const SizedBox(height: DsSpacing.s),
             Text(
-              '別のキーワードで検索してみてください',
+              suggestionMessage ?? '別のキーワードで検索してみてください',
               style: DsTypography.bodySmall.copyWith(
                 color: Theme.of(context).colorScheme.onSurfaceVariant,
               ),

--- a/packages/design_system/lib/src/components/ds_shimmer.dart
+++ b/packages/design_system/lib/src/components/ds_shimmer.dart
@@ -52,10 +52,10 @@ class DsShimmer extends StatelessWidget {
   }
 }
 
-/// Pokemon一覧表示用のShimmerアイテム。
-class DsPokemonListShimmer extends StatelessWidget {
-  /// Pokemon一覧表示用のShimmerアイテムを作成する。
-  const DsPokemonListShimmer({super.key});
+/// リスト項目表示用のShimmerアイテム。
+class DsListItemShimmer extends StatelessWidget {
+  /// リスト項目表示用のShimmerアイテムを作成する。
+  const DsListItemShimmer({super.key});
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## 対応する Issue

Closes #38

## リンク

N/A

## やったこと

- 存在しない`ds_evolution_effects.dart`、`ds_evolution_sequence.dart`のexportを`design_system.dart`から削除
- `DsPokemonListShimmer`を`DsListItemShimmer`に名称変更し、Pokemon固有の命名を汎用化
- `DsSearchEmptyState`のメッセージをパラメータ化（`emptyMessage`、`suggestionMessage`）して汎用化
- 進化関連コンポーネント（`evolution_effects.dart`、`evolution_sequence.dart`）をdesign_systemパッケージからappパッケージの`ui/features/evolution/components/`に移動
- 不足していた`DsEvolutionPokemonImage`コンポーネントをevolution_effects.dartに追加
- `RadialBurst`の参照を`DsRadialBurst`に修正
- 必要なimport文を追加し、未使用のimport文を削除

## やらなかったこと

- 既存の汎用コンポーネント（DsButton、DsScaffold等）の変更は不要だったため実施せず
- 新規テストの追加（既存の機能を移動・汎用化のみのため）

## ユーザーへの影響

- **機能への影響なし**: 既存の機能は全て維持され、見た目や動作に変更はありません
- **開発者への影響**: design_systemパッケージがより汎用的になり、他のドメインでも再利用可能になりました

## 動作確認

### 確認した環境

- 開発環境でのコンパイル確認

### 確認したこと

- `make analyze` - 静的解析エラーなし
- `make format_all` - コードフォーマット確認
- コンパイルエラーが発生しないことを確認
- 進化関連コンポーネントの移動後にimport/exportが正常に動作することを確認

### 確認しなかった（できなかった）こと

- 実機・エミュレータでの動作確認（UIに変更がないため、コンパイル確認のみ実施）
- 進化機能の実際の動作確認（現在ルーティングが統合されていないため）

## その他

### 変更ファイル

- `packages/design_system/lib/design_system.dart` - evolution関連exportを削除
- `packages/design_system/lib/src/components/ds_shimmer.dart` - Pokemon固有命名を汎用化
- `packages/design_system/lib/src/components/ds_search_bar.dart` - メッセージのパラメータ化
- `packages/app/lib/ui/pages/pokedex_page.dart` - コンポーネント名変更対応
- `packages/app/lib/ui/features/evolution/components/evolution_effects.dart` - 移動・コンポーネント追加
- `packages/app/lib/ui/features/evolution/components/evolution_sequence.dart` - 移動・import修正
- `packages/app/lib/ui/features/evolution/components/evolution_result_content.dart` - import修正

### アーキテクチャの改善

本リファクタリングにより、design_systemパッケージが純粋な汎用UIコンポーネントライブラリとして整理され、Clean Architectureの原則により適合するようになりました。今後は他のドメインでも再利用可能なデザインシステムとして機能します。