### PR TITLE
feat: domainパッケージのuseCaseを通常クラス+関数ベースProviderに変更

### DIFF
--- a/packages/app/lib/ui/pages/evolution_confirmation_page.dart
+++ b/packages/app/lib/ui/pages/evolution_confirmation_page.dart
@@ -72,7 +72,7 @@ class EvolutionConfirmationPage extends HookConsumerWidget {
 
                     // 進化処理を実行
                     final evolutionUseCase =
-                        ref.read(evolvePokemonUseCaseProvider.notifier);
+                        ref.read(evolvePokemonUseCaseProvider);
                     final result =
                         await evolutionUseCase.evolve(params.partyPokemonId);
 

--- a/packages/domain/lib/src/features/pokemon/evolve_pokemon_use_case.dart
+++ b/packages/domain/lib/src/features/pokemon/evolve_pokemon_use_case.dart
@@ -1,5 +1,7 @@
+import 'package:data/src/services/local_storage/database.dart';
 import 'package:data/src/services/local_storage/local_database_provider.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/foundation.dart';
 
 import '../../core/core.dart';
@@ -30,12 +32,10 @@ class EvolutionData {
 }
 
 /// ポケモンの進化処理を実行するUseCase。
-@riverpod
-class EvolvePokemonUseCase extends _$EvolvePokemonUseCase {
-  @override
-  void build() {
-    // このUseCaseは状態を持たない
-  }
+class EvolvePokemonUseCase {
+  const EvolvePokemonUseCase(this._localDatabase);
+
+  final LocalDatabase _localDatabase;
 
   /// 指定されたパーティポケモンを進化させる。
   ///
@@ -47,7 +47,7 @@ class EvolvePokemonUseCase extends _$EvolvePokemonUseCase {
       debugPrint(
           'EvolvePokemonUseCase.evolve: Starting evolution for partyPokemonId=$partyPokemonId');
 
-      final database = ref.read(localDatabaseProvider);
+      final database = _localDatabase;
 
       // パーティポケモンの情報を取得
       final partyPokemon = await (database.select(database.partyPokemons)
@@ -127,7 +127,7 @@ class EvolvePokemonUseCase extends _$EvolvePokemonUseCase {
       debugPrint(
           'EvolvePokemonUseCase.devolve: Starting devolution for partyPokemonId=$partyPokemonId');
 
-      final database = ref.read(localDatabaseProvider);
+      final database = _localDatabase;
 
       // パーティポケモンの情報を取得
       final partyPokemon = await (database.select(database.partyPokemons)
@@ -209,4 +209,11 @@ class EvolvePokemonUseCase extends _$EvolvePokemonUseCase {
   static int? checkDevolutionPossibility(int pokemonId) {
     return EvolutionDataHelper.getDevolutionTarget(pokemonId);
   }
+}
+
+/// EvolvePokemonUseCaseのProvider。
+@riverpod
+EvolvePokemonUseCase evolvePokemonUseCase(Ref ref) {
+  final localDatabase = ref.read(localDatabaseProvider);
+  return EvolvePokemonUseCase(localDatabase);
 }

--- a/packages/domain/lib/src/features/pokemon/evolve_pokemon_use_case.g.dart
+++ b/packages/domain/lib/src/features/pokemon/evolve_pokemon_use_case.g.dart
@@ -7,15 +7,15 @@ part of 'evolve_pokemon_use_case.dart';
 // **************************************************************************
 
 String _$evolvePokemonUseCaseHash() =>
-    r'6fdbd5cbfc2ca7aac0d35249ea9bef3c5a9ef554';
+    r'1d54a50c505d5d033d0aa2b5148c5c886f3c9cad';
 
-/// ポケモンの進化処理を実行するUseCase。
+/// EvolvePokemonUseCaseのProvider。
 ///
-/// Copied from [EvolvePokemonUseCase].
-@ProviderFor(EvolvePokemonUseCase)
+/// Copied from [evolvePokemonUseCase].
+@ProviderFor(evolvePokemonUseCase)
 final evolvePokemonUseCaseProvider =
-    AutoDisposeNotifierProvider<EvolvePokemonUseCase, void>.internal(
-  EvolvePokemonUseCase.new,
+    AutoDisposeProvider<EvolvePokemonUseCase>.internal(
+  evolvePokemonUseCase,
   name: r'evolvePokemonUseCaseProvider',
   debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
       ? null
@@ -24,6 +24,8 @@ final evolvePokemonUseCaseProvider =
   allTransitiveDependencies: null,
 );
 
-typedef _$EvolvePokemonUseCase = AutoDisposeNotifier<void>;
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+typedef EvolvePokemonUseCaseRef = AutoDisposeProviderRef<EvolvePokemonUseCase>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/packages/domain/test/features/pokemon/evolve_pokemon_use_case_test.dart
+++ b/packages/domain/test/features/pokemon/evolve_pokemon_use_case_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:domain/domain.dart';
+
+void main() {
+  group('EvolvePokemonUseCase - Static Methods', () {
+    test('checkEvolutionPossibility - 進化可能', () {
+      // Arrange
+      const pokemonId = 1; // フシギダネ
+      const breedingCounter = 10;
+
+      // Act
+      final result = EvolvePokemonUseCase.checkEvolutionPossibility(
+        pokemonId,
+        breedingCounter,
+      );
+
+      // Assert
+      expect(result, equals(2)); // フシギソウ
+    });
+
+    test('checkEvolutionPossibility - 育成カウンター不足', () {
+      // Arrange
+      const pokemonId = 1; // フシギダネ
+      const breedingCounter = 5; // 不足
+
+      // Act
+      final result = EvolvePokemonUseCase.checkEvolutionPossibility(
+        pokemonId,
+        breedingCounter,
+      );
+
+      // Assert
+      expect(result, isNull);
+    });
+
+    test('checkEvolutionPossibility - 進化不可能なポケモン', () {
+      // Arrange
+      const pokemonId = 999; // 存在しないポケモン
+      const breedingCounter = 10;
+
+      // Act
+      final result = EvolvePokemonUseCase.checkEvolutionPossibility(
+        pokemonId,
+        breedingCounter,
+      );
+
+      // Assert
+      expect(result, isNull);
+    });
+
+    test('checkDevolutionPossibility - 退化可能', () {
+      // Arrange
+      const pokemonId = 2; // フシギソウ
+
+      // Act
+      final result = EvolvePokemonUseCase.checkDevolutionPossibility(
+        pokemonId,
+      );
+
+      // Assert
+      expect(result, equals(1)); // フシギダネ
+    });
+
+    test('checkDevolutionPossibility - 退化不可能', () {
+      // Arrange
+      const pokemonId = 1; // フシギダネ（退化不可能）
+
+      // Act
+      final result = EvolvePokemonUseCase.checkDevolutionPossibility(
+        pokemonId,
+      );
+
+      // Assert
+      expect(result, isNull);
+    });
+
+    test('checkDevolutionPossibility - 存在しないポケモン', () {
+      // Arrange
+      const pokemonId = 999; // 存在しないポケモン
+
+      // Act
+      final result = EvolvePokemonUseCase.checkDevolutionPossibility(
+        pokemonId,
+      );
+
+      // Assert
+      expect(result, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## 対応する Issue

Closes #39

## リンク

特になし

## やったこと

- `EvolvePokemonUseCase`をRiverpodのNotifierクラスから通常クラスに変更
- `LocalDatabase`を依存性注入で受け取る構造に変更
- 関数ベースProvider `evolvePokemonUseCaseProvider`を作成
- 呼び出し側で`.notifier`ではなく直接Providerを参照するよう修正
- static methodのテストを追加してテスタビリティを向上
- Clean Architectureの原則に準拠した実装に改善

## やらなかったこと

- 複雑なmockingを必要とする統合テストの実装（static methodのテストのみ実装）
- 他のuseCaseの同様の変更（現在は`EvolvePokemonUseCase`のみ）

## ユーザーへの影響

- 機能的な変更はなし（内部実装のリファクタリングのみ）
- 進化・退化機能は従来通り動作
- パフォーマンスや動作に影響なし

## 動作確認

### 確認した環境

- 開発環境でのコード解析とテスト実行

### 確認したこと

- domainパッケージのテスト: ✅ 全通過
- Flutter analyzeによるコード解析: ✅ エラーなし
- コードフォーマット: ✅ 適用済み
- static methodのテスト: ✅ 全通過
  - 進化可能性チェック（育成カウンター10以上）
  - 育成カウンター不足の場合
  - 進化不可能なポケモンの場合
  - 退化可能性チェック
  - 退化不可能なポケモンの場合

### 確認しなかった（できなかった）こと

- 実機での動作確認（UIテストは今後実施予定）
- 進化・退化の実際の動作確認（既存機能のため影響なしと判断）

## その他

### 技術的改善点

- **Clean Architecture準拠**: useCaseが純粋なビジネスロジッククラスに
- **テスタビリティ向上**: 依存性注入により単体テストが容易に
- **責任分離**: 状態管理とビジネスロジックを適切に分離
- **再利用性向上**: プラットフォーム非依存のuseCase実装

### 影響範囲

- `packages/domain/lib/src/features/pokemon/evolve_pokemon_use_case.dart`
- `packages/app/lib/ui/pages/evolution_confirmation_page.dart`
- `packages/domain/test/features/pokemon/evolve_pokemon_use_case_test.dart` (新規作成)

🤖 Generated with [Claude Code](https://claude.ai/code)